### PR TITLE
Show latest time entries

### DIFF
--- a/gui/components/LeftMenu.vue
+++ b/gui/components/LeftMenu.vue
@@ -33,7 +33,7 @@
       <v-list>
         <v-list-item
           prepend-icon="mdi-logout"
-          title="Salir"
+          title="Logout"
           value="logout"
           @click="logout"
           v-if="auth.isAuthenticated.value"></v-list-item>

--- a/ticktask/server/schemas/time_entry_schema.py
+++ b/ticktask/server/schemas/time_entry_schema.py
@@ -31,3 +31,13 @@ class TimeEntrySchema(Schema):
     id: int
     clock_in: datetime
     clock_out: datetime | None
+
+
+class TimeEntryHistoryRequestSchema(Schema):
+    """
+    Schema used to request the last time entries of
+    a given `SubTask` during the past `last_hours`.
+    """
+
+    subtask_id: int
+    last_hours: int


### PR DESCRIPTION
This PR addresses the issue where selecting a `SubTask` did not display any contextual information. Now, when a `SubTask` is selected, the application fetches and displays its recent time entries (within the last 24 hours), showing only clock-in and clock-out records relevant to that specific subtask.