### PR TITLE
Allow one clock-in per user

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,5 +77,5 @@ celery -A ticktask worker -l info
 and in a different terminal:
 
 ```sh
-celery -A ticktask worker -l info
+celery -A ticktask beat -l info
 ```

--- a/gui/pages/time-tracking.vue
+++ b/gui/pages/time-tracking.vue
@@ -266,7 +266,6 @@
   }
 
   async function clockOut() {
-    // TODO(David): Clock-out automatically when more than 12 hours have passed
     try {
       console.log("entry id: ", activeTimeEntryId.value);
       const response = await $api("/ticktask/user/clock-out/", {

--- a/gui/pages/time-tracking.vue
+++ b/gui/pages/time-tracking.vue
@@ -216,6 +216,7 @@
         isClockedIn.value = true;
         clockInTime.value = new Date(entry.clock_in);
         startClockInTimer();
+        fetchRecentTimeEntries(activeSubTask.value.id);
       }
     } catch (error) {
       console.error("Error fetching tasks:", error);
@@ -239,12 +240,9 @@
   function selectSubtask(subtask, task) {
     selectedTask.value = task;
     selectedSubtask.value = subtask;
-
-    fetchRecentTimeEntries(subtask.id);
   }
 
   async function clockIn() {
-    // TODO(David): Don't let to clock-in if there are another time entry that has not been closed
     try {
       const response = await $api("/ticktask/user/clock-in/", {
         method: "POST",
@@ -296,7 +294,6 @@
       });
 
       recentTimeEntries.value = response;
-      console.log("HERE: ", recentTimeEntries.value);
     } catch (err) {
       console.error("Error fetching recent time entries:", err);
       recentTimeEntries.value = [];

--- a/gui/pages/time-tracking.vue
+++ b/gui/pages/time-tracking.vue
@@ -244,6 +244,16 @@
 
   async function clockIn() {
     try {
+      const existing = await $api("/ticktask/user/get-clocked-in-time-entry/", {
+        method: "GET",
+      });
+
+      if (existing) {
+        alert(
+          "You have an already active Task. Please, close it before starting a new one."
+        );
+        return;
+      }
       const response = await $api("/ticktask/user/clock-in/", {
         method: "POST",
         body: {

--- a/ticktask/celery_app.py
+++ b/ticktask/celery_app.py
@@ -1,4 +1,7 @@
-# ticktask/celery.py
+"""
+Definition of the settings of my celery app
+"""
+
 import os
 from celery import Celery
 


### PR DESCRIPTION
This PR updates the `clockIn` function to first check the endpoint `/user/get-clocked-in-time-entry/` before creating a new `TimeEntry`.
If the endpoint returns a non-null value (meaning the user already has an active entry), the action is aborted and a clear message is shown to the user.

This change ensures that users cannot start a new clock-in session while another one is still open, preventing incorrect usage of the app.