### PR TITLE
Restructure front

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -1,0 +1,26 @@
+# Installs the frontend dependencies and runs its unit tests.
+
+name: Frontend
+
+on:
+  push:
+    branches: [ "**" ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: gui
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "18"
+          cache: npm
+          cache-dependency-path: gui/package-lock.json
+      - name: Install dependencies
+        run: npm ci
+      - name: Run tests
+        run: npm run test

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -5,9 +5,7 @@ name: Python package
 
 on:
   push:
-    branches: [ "master" ]
-  pull_request:
-    branches: [ "master" ]
+    branches: [ "**" ]
 
 jobs:
   build:
@@ -16,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.12", "3.13"]
 
     steps:
     - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -1,81 +1,63 @@
 # TickTask
 
-⚠️ **This project is currently under active development and not yet ready for production use. Expect changes, bugs, and incomplete features.**
+⚠️ **This project is under active development and not yet ready for production use. Expect changes, bugs, and incomplete features.**
 
-**TickTask** is a web application designed to clock in/out and track time spent on various tasks. It's built with a modern stack: Django + Django Ninja for the backend and Nuxt + Vuetify for the frontend.
+**TickTask** is a web application to clock in/out and track the time spent across
+tasks and subtasks, with a dashboard and a calendar to review past time and plan ahead.
 
----
+## Stack
 
-# Installation Steps
+- **Backend** — Django 5 + Django Ninja (REST API) with JWT auth, Celery + Redis for
+  background jobs, and SQLite for development.
+- **Frontend** — Nuxt 3 (SPA, SSR disabled) styled with Tailwind CSS and Lucide icons.
 
-## Backend: Django + Django Ninja
+## Requirements
+
+- Python ≥ 3.12 and [uv](https://docs.astral.sh/uv/)
+- Node.js ≥ 18 and npm
+- Redis — only needed for the Celery background jobs
+
+## Backend
+
+From the repository root:
 
 ```sh
-uv add django django-ninja django-cors-headers
+uv sync                                       # install dependencies
+uv run python ticktask/manage.py migrate
+uv run python ticktask/manage.py createsuperuser
+uv run python ticktask/manage.py runserver    # http://localhost:8000
 ```
 
-Initialize the project:
+The API is served under `/api`, with interactive docs at <http://localhost:8000/api/docs>.
+
+### Tests
 
 ```sh
-uv run django-admin startproject ticktask .
-uv run python manage.py startapp api
-uv run python manage.py migrate
-uv run python manage.py createsuperuser
-uv run python manage.py runserver
+uv run pytest
 ```
 
-### Run backend
+## Frontend
 
 ```sh
-uv run python manage.py runserver
-```
-
-## Frontend: Nuxt + Vuetify
-
-```sh
-npx nuxi@latest init gui
 cd gui
 npm install
+npm run dev                                   # http://localhost:3000
 ```
 
-### Disable SSR
+The frontend reads the backend URL from `gui/.env` (`NUXT_PUBLIC_API_URL`, defaults to
+`http://localhost:8000/api`). Copy `gui/.env.example` to `gui/.env` to customise it.
 
-```ts
-export default defineNuxtConfig({
-  ssr: false,
-});
-```
+## Celery (optional)
 
-### Add Vuetify
-
-Use the official module to add Vuetify:
-
-```sh
-npx nuxi@latest module add vuetify-nuxt-module
-```
-
-### Run frontend
-
-```sh
-npm run dev
-```
-
-### Run celery
-
-To run the celery app, first we need to make sure that `redis` is installed using:
+The background jobs (e.g. auto-closing stale time entries) need Redis on `:6379`:
 
 ```sh
 docker run -d --name redis -p 6379:6379 redis:7
 ```
 
-then we need to run in a first terminal:
+Then run the worker and the beat scheduler in separate terminals:
 
 ```sh
-celery -A ticktask worker -l info
-```
-
-and in a different terminal:
-
-```sh
-celery -A ticktask beat -l info
+uv run celery -A ticktask worker -l info
+uv run celery -A ticktask beat -l info
 ```

--- a/gui/.env.example
+++ b/gui/.env.example
@@ -1,0 +1,3 @@
+# Base URL of the TickTask backend API.
+# Copy this file to `.env` and adjust if your backend runs elsewhere.
+NUXT_PUBLIC_API_URL=http://localhost:8000/api

--- a/gui/assets/css/tailwind.css
+++ b/gui/assets/css/tailwind.css
@@ -1,0 +1,83 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+@layer base {
+  :root {
+    --background: 247 248 251;
+    --foreground: 15 23 42;
+
+    --card: 255 255 255;
+    --card-foreground: 15 23 42;
+
+    --muted: 241 245 249;
+    --muted-foreground: 100 116 139;
+
+    --border: 226 232 240;
+    --input: 226 232 240;
+    --ring: 0 124 191;
+
+    --primary: 0 124 191;
+    --primary-foreground: 255 255 255;
+
+    --accent: 94 166 17;
+    --accent-foreground: 255 255 255;
+
+    --danger: 211 15 75;
+    --danger-foreground: 255 255 255;
+  }
+
+  .dark {
+    --background: 9 13 24;
+    --foreground: 226 232 240;
+
+    --card: 20 27 43;
+    --card-foreground: 226 232 240;
+
+    --muted: 30 41 59;
+    --muted-foreground: 148 163 184;
+
+    --border: 39 51 73;
+    --input: 39 51 73;
+    --ring: 56 169 226;
+
+    --primary: 45 156 219;
+    --primary-foreground: 255 255 255;
+
+    --accent: 124 191 38;
+    --accent-foreground: 12 20 4;
+
+    --danger: 244 63 110;
+    --danger-foreground: 255 255 255;
+  }
+
+  * {
+    @apply border-border;
+  }
+
+  html {
+    -webkit-font-smoothing: antialiased;
+  }
+
+  body {
+    @apply bg-background text-foreground font-sans;
+  }
+
+  /* Subtle, themed scrollbars */
+  ::-webkit-scrollbar {
+    width: 10px;
+    height: 10px;
+  }
+  ::-webkit-scrollbar-thumb {
+    @apply rounded-full bg-muted-foreground/30;
+  }
+  ::-webkit-scrollbar-thumb:hover {
+    @apply bg-muted-foreground/50;
+  }
+}
+
+@layer components {
+  .card-surface {
+    @apply rounded-2xl border border-border bg-card text-card-foreground shadow-soft;
+  }
+}

--- a/gui/components/AddSubTaskDialog.vue
+++ b/gui/components/AddSubTaskDialog.vue
@@ -1,36 +1,29 @@
 <template>
-  <v-dialog v-model="dialog" max-width="600px" persistent>
-    <v-card>
-      <v-form ref="formRef" @submit.prevent="submitForm">
-        <v-toolbar density="compact" class="bg-transparent">
-          <v-toolbar-title>Crear nueva subtarea</v-toolbar-title>
-          <v-btn icon="mdi-close" @click="dialog = false"></v-btn>
-        </v-toolbar>
+  <UiModal v-model="dialog" title="New subtask">
+    <form id="add-subtask-form" class="space-y-4" @submit.prevent="submitForm">
+      <UiInput
+        v-model="subtaskName"
+        label="Subtask name"
+        placeholder="e.g. Design the homepage"
+        icon="lucide:list-todo"
+        :error="nameError"
+        autofocus />
 
-        <v-card-text>
-          <v-text-field
-            v-model="subtaskName"
-            label="Nombre de la subtarea"
-            :rules="[(v) => !!v || 'El nombre es obligatorio']"
-            variant="underlined"
-            dense />
+      <UiTextarea
+        v-model="subtaskDescription"
+        label="Description"
+        placeholder="What does this subtask involve?"
+        :rows="3"
+        :error="descError" />
+    </form>
 
-          <v-textarea
-            v-model="subtaskDescription"
-            label="Descripción"
-            :rules="[(v) => !!v || 'La descripción es obligatoria']"
-            variant="underlined"
-            rows="3"
-            dense />
-        </v-card-text>
-
-        <v-card-actions>
-          <v-spacer />
-          <v-btn color="primary" variant="flat" type="submit"> Crear </v-btn>
-        </v-card-actions>
-      </v-form>
-    </v-card>
-  </v-dialog>
+    <template #footer>
+      <UiButton variant="ghost" @click="dialog = false">Cancel</UiButton>
+      <UiButton type="submit" form="add-subtask-form" :loading="loading"
+        >Create subtask</UiButton
+      >
+    </template>
+  </UiModal>
 </template>
 
 <script setup>
@@ -38,7 +31,7 @@
 
   const props = defineProps({
     modelValue: Boolean,
-    taskId: Number, // Tarea asociada
+    taskId: Number,
   });
 
   const emit = defineEmits(["update:modelValue", "subtask-created"]);
@@ -46,31 +39,34 @@
   const { $api } = useNuxtApp();
 
   const dialog = ref(props.modelValue);
-  const formRef = ref(null);
   const subtaskName = ref("");
   const subtaskDescription = ref("");
+  const nameError = ref("");
+  const descError = ref("");
+  const loading = ref(false);
 
   watch(
     () => props.modelValue,
     (val) => {
       dialog.value = val;
-    }
+      if (val) resetForm();
+    },
   );
 
-  watch(dialog, (val) => {
-    emit("update:modelValue", val);
-  });
+  watch(dialog, (val) => emit("update:modelValue", val));
 
   async function submitForm() {
-    const valid = await formRef.value.validate();
-    if (!valid) return;
+    if (loading.value) return;
+    nameError.value = "";
+    descError.value = "";
 
+    if (!subtaskName.value.trim()) nameError.value = "The name is required.";
+    if (!subtaskDescription.value.trim())
+      descError.value = "The description is required.";
+    if (nameError.value || descError.value) return;
+
+    loading.value = true;
     try {
-      console.log("Subtask: ", {
-        name: subtaskName.value.trim(),
-        description: subtaskDescription.value.trim(),
-        task_id: props.taskId,
-      });
       const response = await $api("/ticktask/user/create-subtask/", {
         method: "POST",
         body: {
@@ -81,16 +77,19 @@
       });
 
       emit("subtask-created", response);
-      resetForm();
       dialog.value = false;
-    } catch (error) {
-      console.error("Error al crear subtarea:", error);
+    } catch (err) {
+      nameError.value = "Couldn't create the subtask. Does it already exist?";
+      console.error("Error creating subtask:", err);
+    } finally {
+      loading.value = false;
     }
   }
 
   function resetForm() {
     subtaskName.value = "";
     subtaskDescription.value = "";
-    formRef.value.resetValidation();
+    nameError.value = "";
+    descError.value = "";
   }
 </script>

--- a/gui/components/AddTaskDialog.vue
+++ b/gui/components/AddTaskDialog.vue
@@ -1,28 +1,23 @@
 <template>
-  <v-dialog v-model="dialog" max-width="500px" persistent>
-    <v-card>
-      <v-form ref="formRef" @submit.prevent="submitForm">
-        <v-toolbar density="compact" class="bg-transparent">
-          <v-toolbar-title>Crear nueva tarea</v-toolbar-title>
-          <v-btn icon="mdi-close" @click="dialog = false"></v-btn>
-        </v-toolbar>
+  <UiModal v-model="dialog" title="New task">
+    <form id="add-task-form" class="space-y-4" @submit.prevent="submitForm">
+      <UiInput
+        v-model="taskName"
+        label="Task name"
+        placeholder="e.g. Website redesign"
+        icon="lucide:folder"
+        :error="error"
+        autofocus
+        @enter="submitForm" />
+    </form>
 
-        <v-card-text>
-          <v-text-field
-            v-model="taskName"
-            label="Nombre de la tarea"
-            :rules="[(v) => !!v || 'El nombre es obligatorio']"
-            variant="underlined"
-            dense />
-        </v-card-text>
-
-        <v-card-actions>
-          <v-spacer />
-          <v-btn color="primary" variant="flat" type="submit"> Crear </v-btn>
-        </v-card-actions>
-      </v-form>
-    </v-card>
-  </v-dialog>
+    <template #footer>
+      <UiButton variant="ghost" @click="dialog = false">Cancel</UiButton>
+      <UiButton type="submit" form="add-task-form" :loading="loading"
+        >Create task</UiButton
+      >
+    </template>
+  </UiModal>
 </template>
 
 <script setup>
@@ -37,42 +32,48 @@
   const { $api } = useNuxtApp();
 
   const dialog = ref(props.modelValue);
-  const formRef = ref(null);
   const taskName = ref("");
+  const error = ref("");
+  const loading = ref(false);
 
   watch(
     () => props.modelValue,
     (val) => {
       dialog.value = val;
-    }
+      if (val) resetForm();
+    },
   );
 
-  watch(dialog, (val) => {
-    emit("update:modelValue", val);
-  });
+  watch(dialog, (val) => emit("update:modelValue", val));
 
   async function submitForm() {
-    const valid = await formRef.value.validate();
-    if (!valid) return;
+    if (loading.value) return;
+    error.value = "";
 
+    if (!taskName.value.trim()) {
+      error.value = "The name is required.";
+      return;
+    }
+
+    loading.value = true;
     try {
       const response = await $api("/ticktask/user/create-task/", {
         method: "POST",
-        body: {
-          name: taskName.value.trim(),
-        },
+        body: { name: taskName.value.trim() },
       });
 
       emit("task-created", response);
-      resetForm();
       dialog.value = false;
-    } catch (error) {
-      console.error("Error al crear tarea:", error);
+    } catch (err) {
+      error.value = "Couldn't create the task. Does it already exist?";
+      console.error("Error creating task:", err);
+    } finally {
+      loading.value = false;
     }
   }
 
   function resetForm() {
     taskName.value = "";
-    formRef.value.resetValidation();
+    error.value = "";
   }
 </script>

--- a/gui/components/Header.vue
+++ b/gui/components/Header.vue
@@ -1,38 +1,38 @@
 <template>
-  <v-app-bar app color="primary">
-    <v-img
-      src="/logo_white.png"
-      max-width="40"
-      class="mx-6 my-5"
-      title="TickTask" />
-    <v-app-bar-title>Tick-Task</v-app-bar-title>
-    <template v-slot:append>
-      <v-btn text to="/" prepend-icon="mdi-home-variant">Inicio</v-btn>
-      <v-btn
-        text
-        to="/login"
-        v-if="!auth.isAuthenticated.value"
-        class="ml-2"
-        prepend-icon="mdi-login"
-        >Login</v-btn
-      >
-      <v-btn
-        text
-        @click="logout()"
-        v-if="auth.isAuthenticated.value"
-        prepend-icon="mdi-logout"
-        class="ml-2"
-        >Logout</v-btn
-      >
-    </template>
-  </v-app-bar>
+  <header
+    class="sticky top-0 z-30 border-b border-border bg-background/80 backdrop-blur">
+    <div class="mx-auto flex h-16 max-w-6xl items-center gap-3 px-4 sm:px-6">
+      <NuxtLink to="/" class="flex items-center gap-2.5">
+        <div
+          class="flex size-9 items-center justify-center rounded-xl bg-primary text-primary-foreground shadow-soft">
+          <Icon name="lucide:timer" class="size-5" />
+        </div>
+        <span class="text-lg font-bold tracking-tight">TickTask</span>
+      </NuxtLink>
+
+      <div class="ml-auto flex items-center gap-1.5">
+        <UiThemeToggle />
+        <UiButton
+          v-if="auth.isAuthenticated.value"
+          to="/home"
+          variant="secondary"
+          size="sm"
+          icon="lucide:layout-dashboard">
+          Open app
+        </UiButton>
+        <UiButton
+          v-else
+          to="/login"
+          variant="primary"
+          size="sm"
+          icon="lucide:log-in">
+          Log in
+        </UiButton>
+      </div>
+    </div>
+  </header>
 </template>
 
 <script setup>
   const auth = useAuth();
-
-  const logout = () => {
-    auth.logout();
-    navigateTo("/login");
-  };
 </script>

--- a/gui/components/Home.vue
+++ b/gui/components/Home.vue
@@ -1,41 +1,91 @@
 <template>
-  <v-container class="mx-auto">
-    <v-row justify="center" align="center" class="text-center" no-gutters>
-      <v-col cols="12" md="4">
-        <v-btn
-          @click="goTo('time-tracking')"
-          variant="text"
-          size="200"
-          stacked
-          color="primary">
-          <v-icon size="150">mdi-clock-in</v-icon>
-          <span class="mt-2 text-lg font-semibold text-gray-800"
-            >Time track</span
-          >
-        </v-btn>
-      </v-col>
+  <div class="mx-auto max-w-6xl space-y-8">
+    <!-- Greeting -->
+    <div>
+      <h1 class="text-2xl font-bold tracking-tight sm:text-3xl">
+        {{ greeting }}
+      </h1>
+      <p class="mt-1 text-muted-foreground">
+        Here's your TickTask workspace. What's next?
+      </p>
+    </div>
 
-      <v-col cols="12" md="4">
-        <v-btn
-          @click="goTo('time-history')"
-          variant="text"
-          size="200"
-          stacked
-          color="primary">
-          <v-icon size="150">mdi-history</v-icon>
-          <span class="mt-2 text-lg font-semibold text-gray-800"
-            >Tracker history</span
-          >
-        </v-btn>
-      </v-col>
-    </v-row>
-  </v-container>
+    <!-- Quick actions -->
+    <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+      <NuxtLink
+        v-for="action in actions"
+        :key="action.to"
+        :to="action.to"
+        class="card-surface group flex flex-col gap-3 p-5 transition-all hover:-translate-y-0.5 hover:shadow-card">
+        <div
+          class="flex size-11 items-center justify-center rounded-xl transition-colors"
+          :class="action.tint">
+          <Icon :name="action.icon" class="size-5" />
+        </div>
+        <div>
+          <h3 class="font-semibold">{{ action.title }}</h3>
+          <p class="mt-0.5 text-sm text-muted-foreground">{{ action.text }}</p>
+        </div>
+        <span
+          class="mt-auto inline-flex items-center gap-1 text-sm font-medium text-primary opacity-0 transition-opacity group-hover:opacity-100">
+          Open <Icon name="lucide:arrow-right" class="size-4" />
+        </span>
+      </NuxtLink>
+    </div>
+
+    <!-- Placeholder for upcoming overview widgets -->
+    <UiCard
+      title="At a glance"
+      subtitle="Summary widgets will appear here as the dashboard takes shape.">
+      <div
+        class="flex flex-col items-center justify-center gap-2 py-10 text-center text-muted-foreground">
+        <Icon name="lucide:sparkles" class="size-8" />
+        <p class="text-sm">
+          Your time stats and upcoming events will show up here.
+        </p>
+      </div>
+    </UiCard>
+  </div>
 </template>
 
 <script setup>
-  const router = useRouter();
+  import { computed } from "vue";
 
-  function goTo(path) {
-    router.push(`/${path}`);
-  }
+  const greeting = computed(() => {
+    const h = new Date().getHours();
+    if (h < 12) return "Good morning";
+    if (h < 18) return "Good afternoon";
+    return "Good evening";
+  });
+
+  const actions = [
+    {
+      title: "Time tracking",
+      text: "Clock in and out of your tasks.",
+      to: "/time-tracking",
+      icon: "lucide:timer",
+      tint: "bg-primary/10 text-primary",
+    },
+    {
+      title: "Dashboard",
+      text: "See hours spent per task.",
+      to: "/dashboard",
+      icon: "lucide:chart-column",
+      tint: "bg-accent/10 text-accent",
+    },
+    {
+      title: "Calendar",
+      text: "Plan and review your agenda.",
+      to: "/calendar",
+      icon: "lucide:calendar-days",
+      tint: "bg-primary/10 text-primary",
+    },
+    {
+      title: "History",
+      text: "Browse past time entries.",
+      to: "/time-history",
+      icon: "lucide:history",
+      tint: "bg-muted text-muted-foreground",
+    },
+  ];
 </script>

--- a/gui/components/LeftMenu.vue
+++ b/gui/components/LeftMenu.vue
@@ -1,53 +1,110 @@
 <template>
-  <v-navigation-drawer color="primary" expand-on-hover v-model:rail="rail">
-    <v-img
-      src="/logo_white.png"
-      max-width="40"
-      class="mx-auto my-5"
-      title="TickTask" />
+  <!-- Mobile backdrop -->
+  <Transition name="fade">
+    <div
+      v-if="open"
+      class="fixed inset-0 z-40 bg-slate-950/50 backdrop-blur-sm lg:hidden"
+      @click="emit('close')"></div>
+  </Transition>
 
-    <v-divider></v-divider>
+  <aside
+    :class="[
+      'fixed inset-y-0 left-0 z-40 flex w-64 flex-col border-r border-border bg-card transition-transform duration-200 lg:static lg:translate-x-0',
+      open ? 'translate-x-0' : '-translate-x-full',
+    ]">
+    <!-- Brand -->
+    <div class="flex h-16 items-center gap-2.5 px-4">
+      <div
+        class="flex size-9 items-center justify-center rounded-xl bg-primary text-primary-foreground shadow-soft">
+        <Icon name="lucide:timer" class="size-5" />
+      </div>
+      <span class="text-lg font-bold tracking-tight">TickTask</span>
+      <div class="ml-auto">
+        <UiThemeToggle />
+      </div>
+    </div>
 
-    <v-list>
-      <v-list-item
-        prepend-icon="mdi-home"
-        title="Home"
-        value="home"
-        to="/home"></v-list-item>
+    <!-- Nav -->
+    <nav class="flex-1 space-y-1 overflow-y-auto px-3 py-4">
+      <NuxtLink
+        v-for="item in items"
+        :key="item.to"
+        :to="item.to"
+        class="group flex items-center gap-3 rounded-xl px-3 py-2.5 text-sm font-medium transition-colors"
+        :class="
+          isActive(item.to)
+            ? 'bg-primary/10 text-primary'
+            : 'text-muted-foreground hover:bg-muted hover:text-foreground'
+        "
+        @click="emit('navigate')">
+        <Icon :name="item.icon" class="size-[18px]" />
+        {{ item.label }}
+      </NuxtLink>
+    </nav>
 
-      <v-divider class="my-2"></v-divider>
-
-      <v-list-item
-        prepend-icon="mdi-clock-in"
-        title="Time track"
-        value="time-tracking"
-        to="/time-tracking"></v-list-item>
-      <v-list-item
-        prepend-icon="mdi-history"
-        title="Tracker history"
-        value="time-history"
-        to="/time-history"></v-list-item>
-    </v-list>
-
-    <template v-slot:append>
-      <v-list>
-        <v-list-item
-          prepend-icon="mdi-logout"
-          title="Logout"
-          value="logout"
-          @click="logout"
-          v-if="auth.isAuthenticated.value"></v-list-item>
-      </v-list>
-    </template>
-  </v-navigation-drawer>
+    <!-- Account -->
+    <div class="border-t border-border p-3">
+      <div class="flex items-center gap-3 rounded-xl px-3 py-2">
+        <div
+          class="flex size-9 items-center justify-center rounded-full bg-muted text-sm font-semibold text-muted-foreground">
+          {{ initials }}
+        </div>
+        <div class="min-w-0 flex-1">
+          <p class="truncate text-sm font-medium">{{ displayName }}</p>
+          <p class="truncate text-xs text-muted-foreground">Signed in</p>
+        </div>
+        <button
+          class="rounded-lg p-1.5 text-muted-foreground transition-colors hover:bg-danger/10 hover:text-danger"
+          title="Log out"
+          @click="logout">
+          <Icon name="lucide:log-out" class="size-[18px]" />
+        </button>
+      </div>
+    </div>
+  </aside>
 </template>
 
 <script setup>
+  import { computed } from "vue";
+
+  defineProps({
+    open: { type: Boolean, default: false },
+  });
+
+  const emit = defineEmits(["close", "navigate"]);
+
   const auth = useAuth();
-  const rail = ref(false);
+  const route = useRoute();
+
+  const items = [
+    { label: "Overview", to: "/home", icon: "lucide:layout-dashboard" },
+    { label: "Time tracking", to: "/time-tracking", icon: "lucide:timer" },
+    { label: "Dashboard", to: "/dashboard", icon: "lucide:chart-column" },
+    { label: "Calendar", to: "/calendar", icon: "lucide:calendar-days" },
+    { label: "History", to: "/time-history", icon: "lucide:history" },
+  ];
+
+  const isActive = (to) => route.path === to;
+
+  const displayName = computed(
+    () => auth.user.value?.username || auth.user.value?.name || "My account",
+  );
+
+  const initials = computed(() => displayName.value.slice(0, 2).toUpperCase());
 
   const logout = () => {
     auth.logout();
     navigateTo("/login");
   };
 </script>
+
+<style scoped>
+  .fade-enter-active,
+  .fade-leave-active {
+    transition: opacity 0.2s ease;
+  }
+  .fade-enter-from,
+  .fade-leave-to {
+    opacity: 0;
+  }
+</style>

--- a/gui/components/ui/Alert.vue
+++ b/gui/components/ui/Alert.vue
@@ -1,0 +1,37 @@
+<template>
+  <div
+    class="flex items-start gap-3 rounded-xl border px-4 py-3 text-sm"
+    :class="styles[variant].box">
+    <Icon
+      :name="styles[variant].icon"
+      class="mt-0.5 size-[18px] shrink-0"
+      :class="styles[variant].iconColor" />
+    <div class="min-w-0">
+      <slot />
+    </div>
+  </div>
+</template>
+
+<script setup>
+  defineProps({
+    variant: { type: String, default: "info" }, // info | success | danger
+  });
+
+  const styles = {
+    info: {
+      box: "border-primary/20 bg-primary/10 text-foreground",
+      icon: "lucide:info",
+      iconColor: "text-primary",
+    },
+    success: {
+      box: "border-accent/25 bg-accent/10 text-foreground",
+      icon: "lucide:circle-check",
+      iconColor: "text-accent",
+    },
+    danger: {
+      box: "border-danger/25 bg-danger/10 text-foreground",
+      icon: "lucide:circle-alert",
+      iconColor: "text-danger",
+    },
+  };
+</script>

--- a/gui/components/ui/Button.vue
+++ b/gui/components/ui/Button.vue
@@ -1,0 +1,65 @@
+<template>
+  <component
+    :is="to ? NuxtLink : 'button'"
+    :to="to"
+    :type="to ? undefined : type"
+    :disabled="!to && (disabled || loading)"
+    :class="classes">
+    <Icon
+      v-if="loading"
+      name="lucide:loader-circle"
+      class="animate-spin"
+      :class="iconSize" />
+    <Icon v-else-if="icon" :name="icon" :class="iconSize" />
+    <span v-if="$slots.default" :class="{ 'opacity-0': loading && !icon }">
+      <slot />
+    </span>
+  </component>
+</template>
+
+<script setup>
+  import { computed } from "vue";
+  import { NuxtLink } from "#components";
+
+  const props = defineProps({
+    variant: { type: String, default: "primary" }, // primary | secondary | ghost | outline | danger
+    size: { type: String, default: "md" }, // sm | md | lg | icon
+    icon: { type: String, default: "" },
+    to: { type: [String, Object], default: null },
+    type: { type: String, default: "button" },
+    block: { type: Boolean, default: false },
+    loading: { type: Boolean, default: false },
+    disabled: { type: Boolean, default: false },
+  });
+
+  const variants = {
+    primary:
+      "bg-primary text-primary-foreground hover:bg-primary/90 shadow-soft",
+    secondary: "bg-muted text-foreground hover:bg-muted/70",
+    ghost:
+      "bg-transparent text-muted-foreground hover:bg-muted hover:text-foreground",
+    outline:
+      "border border-border bg-transparent text-foreground hover:bg-muted",
+    danger: "bg-danger text-danger-foreground hover:bg-danger/90 shadow-soft",
+  };
+
+  const sizes = {
+    sm: "h-8 px-3 text-sm gap-1.5",
+    md: "h-10 px-4 text-sm gap-2",
+    lg: "h-12 px-6 text-base gap-2",
+    icon: "h-10 w-10",
+  };
+
+  const iconSize = computed(() =>
+    props.size === "sm" ? "size-4" : "size-[18px]",
+  );
+
+  const classes = computed(() => [
+    "inline-flex items-center justify-center rounded-xl font-medium transition-colors",
+    "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
+    "disabled:pointer-events-none disabled:opacity-50",
+    variants[props.variant],
+    sizes[props.size],
+    props.block ? "w-full" : "",
+  ]);
+</script>

--- a/gui/components/ui/Card.vue
+++ b/gui/components/ui/Card.vue
@@ -1,0 +1,27 @@
+<template>
+  <div class="card-surface" :class="padded ? 'p-6' : ''">
+    <div
+      v-if="$slots.header || title"
+      class="mb-4 flex items-start justify-between gap-4">
+      <div>
+        <h3 v-if="title" class="text-base font-semibold tracking-tight">
+          {{ title }}
+        </h3>
+        <p v-if="subtitle" class="mt-0.5 text-sm text-muted-foreground">
+          {{ subtitle }}
+        </p>
+        <slot name="header" />
+      </div>
+      <slot name="actions" />
+    </div>
+    <slot />
+  </div>
+</template>
+
+<script setup>
+  defineProps({
+    title: { type: String, default: "" },
+    subtitle: { type: String, default: "" },
+    padded: { type: Boolean, default: true },
+  });
+</script>

--- a/gui/components/ui/Input.vue
+++ b/gui/components/ui/Input.vue
@@ -1,0 +1,63 @@
+<template>
+  <div class="w-full">
+    <label
+      v-if="label"
+      :for="id"
+      class="mb-1.5 block text-sm font-medium text-foreground">
+      {{ label }}
+    </label>
+    <div class="relative">
+      <Icon
+        v-if="icon"
+        :name="icon"
+        class="pointer-events-none absolute left-3 top-1/2 size-[18px] -translate-y-1/2 text-muted-foreground" />
+      <input
+        :id="id"
+        :type="revealable && revealed ? 'text' : type"
+        :value="modelValue"
+        :placeholder="placeholder"
+        :autofocus="autofocus"
+        :autocomplete="autocomplete"
+        :class="[
+          'h-11 w-full rounded-xl border bg-card text-foreground placeholder:text-muted-foreground transition-colors',
+          'focus:outline-none focus:ring-2 focus:ring-ring focus:border-transparent',
+          icon ? 'pl-10' : 'pl-3.5',
+          revealable ? 'pr-10' : 'pr-3.5',
+          error ? 'border-danger' : 'border-input',
+        ]"
+        @input="$emit('update:modelValue', $event.target.value)"
+        @keyup.enter="$emit('enter')" />
+      <button
+        v-if="revealable"
+        type="button"
+        class="absolute right-2.5 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+        @click="revealed = !revealed">
+        <Icon
+          :name="revealed ? 'lucide:eye' : 'lucide:eye-off'"
+          class="size-[18px]" />
+      </button>
+    </div>
+    <p v-if="error" class="mt-1.5 text-sm text-danger">{{ error }}</p>
+  </div>
+</template>
+
+<script setup>
+  import { ref, useId } from "vue";
+
+  defineProps({
+    modelValue: { type: [String, Number], default: "" },
+    label: { type: String, default: "" },
+    placeholder: { type: String, default: "" },
+    type: { type: String, default: "text" },
+    icon: { type: String, default: "" },
+    error: { type: String, default: "" },
+    autofocus: { type: Boolean, default: false },
+    autocomplete: { type: String, default: "off" },
+    revealable: { type: Boolean, default: false },
+  });
+
+  defineEmits(["update:modelValue", "enter"]);
+
+  const id = useId();
+  const revealed = ref(false);
+</script>

--- a/gui/components/ui/Modal.vue
+++ b/gui/components/ui/Modal.vue
@@ -1,0 +1,63 @@
+<template>
+  <Teleport to="body">
+    <Transition name="overlay">
+      <div
+        v-if="modelValue"
+        class="fixed inset-0 z-50 flex items-center justify-center p-4"
+        @keydown.esc="close">
+        <div
+          class="absolute inset-0 bg-slate-950/50 backdrop-blur-sm"
+          @click="close"></div>
+
+        <div
+          class="relative w-full animate-scale-in card-surface shadow-card"
+          :style="{ maxWidth }"
+          role="dialog"
+          aria-modal="true">
+          <div
+            class="flex items-center justify-between border-b border-border px-6 py-4">
+            <h3 class="text-base font-semibold tracking-tight">{{ title }}</h3>
+            <button
+              class="rounded-lg p-1.5 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+              @click="close">
+              <Icon name="lucide:x" class="size-5" />
+            </button>
+          </div>
+
+          <div class="px-6 py-5">
+            <slot />
+          </div>
+
+          <div
+            v-if="$slots.footer"
+            class="flex justify-end gap-2 border-t border-border px-6 py-4">
+            <slot name="footer" />
+          </div>
+        </div>
+      </div>
+    </Transition>
+  </Teleport>
+</template>
+
+<script setup>
+  const props = defineProps({
+    modelValue: { type: Boolean, default: false },
+    title: { type: String, default: "" },
+    maxWidth: { type: String, default: "32rem" },
+  });
+
+  const emit = defineEmits(["update:modelValue"]);
+
+  const close = () => emit("update:modelValue", false);
+</script>
+
+<style scoped>
+  .overlay-enter-active,
+  .overlay-leave-active {
+    transition: opacity 0.18s ease;
+  }
+  .overlay-enter-from,
+  .overlay-leave-to {
+    opacity: 0;
+  }
+</style>

--- a/gui/components/ui/Textarea.vue
+++ b/gui/components/ui/Textarea.vue
@@ -1,0 +1,38 @@
+<template>
+  <div class="w-full">
+    <label
+      v-if="label"
+      :for="id"
+      class="mb-1.5 block text-sm font-medium text-foreground">
+      {{ label }}
+    </label>
+    <textarea
+      :id="id"
+      :value="modelValue"
+      :placeholder="placeholder"
+      :rows="rows"
+      :class="[
+        'w-full rounded-xl border bg-card px-3.5 py-2.5 text-foreground placeholder:text-muted-foreground transition-colors',
+        'focus:outline-none focus:ring-2 focus:ring-ring focus:border-transparent resize-y',
+        error ? 'border-danger' : 'border-input',
+      ]"
+      @input="$emit('update:modelValue', $event.target.value)"></textarea>
+    <p v-if="error" class="mt-1.5 text-sm text-danger">{{ error }}</p>
+  </div>
+</template>
+
+<script setup>
+  import { useId } from "vue";
+
+  defineProps({
+    modelValue: { type: String, default: "" },
+    label: { type: String, default: "" },
+    placeholder: { type: String, default: "" },
+    rows: { type: [String, Number], default: 3 },
+    error: { type: String, default: "" },
+  });
+
+  defineEmits(["update:modelValue"]);
+
+  const id = useId();
+</script>

--- a/gui/components/ui/ThemeToggle.vue
+++ b/gui/components/ui/ThemeToggle.vue
@@ -1,0 +1,14 @@
+<template>
+  <button
+    class="inline-flex size-10 items-center justify-center rounded-xl text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+    :title="theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'"
+    @click="toggle">
+    <Icon
+      :name="theme === 'dark' ? 'lucide:sun' : 'lucide:moon'"
+      class="size-5" />
+  </button>
+</template>
+
+<script setup>
+  const { theme, toggle } = useTheme();
+</script>

--- a/gui/composables/useAuth.js
+++ b/gui/composables/useAuth.js
@@ -72,9 +72,12 @@ export const useAuth = () => {
     const timeLeft = decoded.exp - now;
 
     // Refrescar 30 segundos antes de que expire el token
-    setTimeout(async () => {
-      refresh();
-    }, (timeLeft - 30) * 1000);
+    setTimeout(
+      async () => {
+        refresh();
+      },
+      (timeLeft - 30) * 1000,
+    );
   };
 
   return {

--- a/gui/composables/useTheme.js
+++ b/gui/composables/useTheme.js
@@ -1,0 +1,29 @@
+// Light/dark theme management. Persists choice in localStorage and toggles the
+// `dark` class on <html>, which flips the CSS variables defined in tailwind.css.
+export const useTheme = () => {
+  const theme = useState("theme", () => "light");
+
+  const apply = (value) => {
+    if (!import.meta.client) return;
+    document.documentElement.classList.toggle("dark", value === "dark");
+    localStorage.setItem("theme", value);
+  };
+
+  const setTheme = (value) => {
+    theme.value = value;
+    apply(value);
+  };
+
+  const toggle = () => setTheme(theme.value === "dark" ? "light" : "dark");
+
+  const init = () => {
+    if (!import.meta.client) return;
+    const stored = localStorage.getItem("theme");
+    const prefersDark = window.matchMedia(
+      "(prefers-color-scheme: dark)",
+    ).matches;
+    setTheme(stored || (prefersDark ? "dark" : "light"));
+  };
+
+  return { theme, setTheme, toggle, init };
+};

--- a/gui/layouts/blank.vue
+++ b/gui/layouts/blank.vue
@@ -1,10 +1,7 @@
 <template>
-  <v-app>
-    <v-main>
-      <NuxtPage />
-      <!-- Aquí se cargarán las páginas dinámicamente -->
-    </v-main>
-  </v-app>
+  <div class="min-h-screen bg-background">
+    <slot />
+  </div>
 </template>
 
 <script setup></script>

--- a/gui/layouts/default.vue
+++ b/gui/layouts/default.vue
@@ -1,12 +1,10 @@
 <template>
-  <v-app>
+  <div class="flex min-h-screen flex-col bg-background">
     <Header />
-    <v-main>
-      <NuxtPage />
-      <!-- Aquí se cargarán las páginas dinámicamente -->
-    </v-main>
-    <!-- <Footer /> -->
-  </v-app>
+    <main class="flex-1">
+      <slot />
+    </main>
+  </div>
 </template>
 
 <script setup></script>

--- a/gui/layouts/defaultlogged.vue
+++ b/gui/layouts/defaultlogged.vue
@@ -1,12 +1,34 @@
 <template>
-  <v-app>
-    <LeftMenu />
-    <v-main class="my-10 mx-10">
-      <NuxtPage />
-      <!-- Aquí se cargarán las páginas dinámicamente -->
-    </v-main>
-    <!-- <Footer /> -->
-  </v-app>
+  <div class="flex min-h-screen bg-background">
+    <LeftMenu
+      :open="sidebarOpen"
+      @close="sidebarOpen = false"
+      @navigate="sidebarOpen = false" />
+
+    <div class="flex min-w-0 flex-1 flex-col">
+      <!-- Mobile top bar -->
+      <header
+        class="sticky top-0 z-30 flex h-16 items-center gap-3 border-b border-border bg-background/80 px-4 backdrop-blur lg:hidden">
+        <button
+          class="inline-flex size-10 items-center justify-center rounded-xl text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+          @click="sidebarOpen = true">
+          <Icon name="lucide:menu" class="size-5" />
+        </button>
+        <span class="text-base font-bold tracking-tight">TickTask</span>
+        <div class="ml-auto">
+          <UiThemeToggle />
+        </div>
+      </header>
+
+      <main class="flex-1 p-4 sm:p-6 lg:p-8">
+        <slot />
+      </main>
+    </div>
+  </div>
 </template>
 
-<script setup></script>
+<script setup>
+  import { ref } from "vue";
+
+  const sidebarOpen = ref(false);
+</script>

--- a/gui/nuxt.config.ts
+++ b/gui/nuxt.config.ts
@@ -1,30 +1,20 @@
 // https://nuxt.com/docs/api/configuration/nuxt-config
 export default defineNuxtConfig({
-  compatibilityDate: '2025-05-15',
+  compatibilityDate: "2025-05-15",
   devtools: { enabled: true },
-  modules: ['vuetify-nuxt-module'],
   ssr: false,
-  vuetify: {
-    moduleOptions: {
+  modules: ["@nuxtjs/tailwindcss", "@nuxt/icon"],
+  css: ["~/assets/css/tailwind.css"],
+  icon: {
+    // Bundle only the icons actually used in source, served locally (no runtime fetch).
+    clientBundle: {
+      scan: true,
+      includeCustomCollections: true,
     },
-    vuetifyOptions: {
-      theme: {
-        themes: {
-          light: {
-            dark: false,
-            colors: {
-              primary: '#007CBF',
-              secondary: '#5EA611',
-              error: '#D30F4B'
-            }
-          },
-        },
-      },
-    }
   },
   runtimeConfig: {
     public: {
-      apiBaseUrl: process.env.NUXT_PUBLIC_API_URL || '/api',
+      apiBaseUrl: process.env.NUXT_PUBLIC_API_URL || "/api",
     },
   },
   router: {
@@ -34,10 +24,20 @@ export default defineNuxtConfig({
   },
   app: {
     head: {
-      title: 'TickTask',
+      title: "TickTask",
       link: [
-        { rel: 'icon', type: 'image/png', href: '/favicon.png' },
-      ]
-    }
-  }
-})
+        { rel: "icon", type: "image/x-icon", href: "/favicon.ico" },
+        { rel: "preconnect", href: "https://fonts.googleapis.com" },
+        {
+          rel: "preconnect",
+          href: "https://fonts.gstatic.com",
+          crossorigin: "",
+        },
+        {
+          rel: "stylesheet",
+          href: "https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap",
+        },
+      ],
+    },
+  },
+});

--- a/gui/package-lock.json
+++ b/gui/package-lock.json
@@ -16,7 +16,8 @@
       "devDependencies": {
         "@iconify-json/lucide": "^1.2.30",
         "@nuxtjs/tailwindcss": "^6.13.1",
-        "tailwindcss": "^3.4.17"
+        "tailwindcss": "^3.4.17",
+        "vitest": "^2.1.9"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -2893,6 +2894,98 @@
         "vue": "^3.0.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner/node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot/node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/@vue-macros/common": {
       "version": "1.16.1",
       "resolved": "https://registry.npmjs.org/@vue-macros/common/-/common-1.16.1.tgz",
@@ -3366,6 +3459,15 @@
       "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
       "dev": true
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/ast-kit": {
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/ast-kit/-/ast-kit-1.4.3.tgz",
@@ -3778,6 +3880,22 @@
         }
       ]
     },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -3831,6 +3949,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/chokidar": {
@@ -4507,6 +4634,15 @@
         "callsite": "^1.0.0"
       }
     },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/deep-equal": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
@@ -5153,6 +5289,15 @@
       },
       "funding": {
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/exsolve": {
@@ -6793,6 +6938,12 @@
         "node": ">= 12.0.0"
       }
     },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -7944,6 +8095,15 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 14.16"
+      }
     },
     "node_modules/pend": {
       "version": "1.2.0",
@@ -9423,6 +9583,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -9566,6 +9732,12 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true
     },
     "node_modules/standard-as-callback": {
       "version": "2.1.0",
@@ -10180,6 +10352,12 @@
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
       "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg=="
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true
+    },
     "node_modules/tinyexec": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.1.tgz",
@@ -10198,6 +10376,33 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/tmp": {
@@ -11095,6 +11300,596 @@
         "vue": "^3.5.0"
       }
     },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/vitest/node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true
+    },
+    "node_modules/vitest/node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true
+    },
+    "node_modules/vitest/node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/vscode-uri": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
@@ -11186,6 +11981,22 @@
       },
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/winston": {

--- a/gui/package-lock.json
+++ b/gui/package-lock.json
@@ -1,16 +1,34 @@
 {
-  "name": "nuxt-app",
+  "name": "ticktask-gui",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "nuxt-app",
+      "name": "ticktask-gui",
       "hasInstallScript": true,
       "dependencies": {
+        "@nuxt/icon": "^1.10.3",
+        "jwt-decode": "^4.0.0",
         "nuxt": "^3.17.5",
         "vue": "^3.5.16",
-        "vue-router": "^4.5.1",
-        "vuetify-nuxt-module": "^0.18.7"
+        "vue-router": "^4.5.1"
+      },
+      "devDependencies": {
+        "@iconify-json/lucide": "^1.2.30",
+        "@nuxtjs/tailwindcss": "^6.13.1",
+        "tailwindcss": "^3.4.17"
+      }
+    },
+    "node_modules/@alloc/quick-lru": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
+      "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -25,10 +43,14 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/@antfu/utils": {
-      "version": "0.7.10",
-      "resolved": "https://registry.npmjs.org/@antfu/utils/-/utils-0.7.10.tgz",
-      "integrity": "sha512-+562v9k4aI80m1+VuMHehNJWLOFjBnXn3tdOitzD0il5b7smkSBal4+a3oKiQTbrwMmN/TBUMDvbdoWDehgOww==",
+    "node_modules/@antfu/install-pkg": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@antfu/install-pkg/-/install-pkg-1.1.0.tgz",
+      "integrity": "sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==",
+      "dependencies": {
+        "package-manager-detector": "^1.3.0",
+        "tinyexec": "^1.0.1"
+      },
       "funding": {
         "url": "https://github.com/sponsors/antfu"
       }
@@ -421,6 +443,50 @@
       "integrity": "sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==",
       "engines": {
         "node": ">=0.1.90"
+      }
+    },
+    "node_modules/@csstools/selector-resolve-nested": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/selector-resolve-nested/-/selector-resolve-nested-3.1.0.tgz",
+      "integrity": "sha512-mf1LEW0tJLKfWyvn5KdDrhpxHyuxpbNwTIwOYLIvsTffeyOf85j5oIzfG0yosxDgx/sswlqBnESYUcQH0vgZ0g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "postcss-selector-parser": "^7.0.0"
+      }
+    },
+    "node_modules/@csstools/selector-specificity": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-5.0.0.tgz",
+      "integrity": "sha512-PCqQV3c4CoVm3kdPhyeZ07VmBRdH2EpMFA/pd9OASpOEC3aXNGoqPDAZ80D0cLpMBxnmk0+yNhGsEx31hq7Gtw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "postcss-selector-parser": "^7.0.0"
       }
     },
     "node_modules/@dabh/diagnostics": {
@@ -853,6 +919,76 @@
       "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-3.1.1.tgz",
       "integrity": "sha512-5DGmA8FTdB2XbDeEwc/5ZXBl6UbBAyBOOLlPuBnZ/N1SwdH9Ii+cOX3tBROlDgcTXxjOYnLMVoKk9+FXAw0CJw=="
     },
+    "node_modules/@iconify-json/lucide": {
+      "version": "1.2.114",
+      "resolved": "https://registry.npmjs.org/@iconify-json/lucide/-/lucide-1.2.114.tgz",
+      "integrity": "sha512-NbvH3B1BYo6wBtS7joLi7f2UVQOqK2dtZodMFf3kkBs+Tnh9TkRuy8oVHr1RM8UK6bUtvAXxfNlGAah0CuvPCw==",
+      "dev": true,
+      "dependencies": {
+        "@iconify/types": "*"
+      }
+    },
+    "node_modules/@iconify/collections": {
+      "version": "1.0.698",
+      "resolved": "https://registry.npmjs.org/@iconify/collections/-/collections-1.0.698.tgz",
+      "integrity": "sha512-k7lDu5QpRk7arMiSaB8fG2zlQpu3B38q2S1GKnqrJQJPh6ZcTdIB9PWcvaQlYVGEzE2zhRJ1qcZmqHQjrh+/ag==",
+      "dependencies": {
+        "@iconify/types": "*"
+      }
+    },
+    "node_modules/@iconify/types": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@iconify/types/-/types-2.0.0.tgz",
+      "integrity": "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg=="
+    },
+    "node_modules/@iconify/utils": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@iconify/utils/-/utils-2.3.0.tgz",
+      "integrity": "sha512-GmQ78prtwYW6EtzXRU1rY+KwOKfz32PD7iJh6Iyqw68GiKuoZ2A6pRtzWONz5VQJbp50mEjXh/7NkumtrAgRKA==",
+      "dependencies": {
+        "@antfu/install-pkg": "^1.0.0",
+        "@antfu/utils": "^8.1.0",
+        "@iconify/types": "^2.0.0",
+        "debug": "^4.4.0",
+        "globals": "^15.14.0",
+        "kolorist": "^1.8.0",
+        "local-pkg": "^1.0.0",
+        "mlly": "^1.7.4"
+      }
+    },
+    "node_modules/@iconify/utils/node_modules/@antfu/utils": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/@antfu/utils/-/utils-8.1.1.tgz",
+      "integrity": "sha512-Mex9nXf9vR6AhcXmMrlz/HVgYYZpVGJ6YlPgwl7UnaFpnshXs6EK/oa5Gpf3CzENMjkvEx2tQtntGnb7UtSTOQ==",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@iconify/utils/node_modules/globals": {
+      "version": "15.15.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-15.15.0.tgz",
+      "integrity": "sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg==",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@iconify/vue": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@iconify/vue/-/vue-5.0.1.tgz",
+      "integrity": "sha512-aumwwooJlFJ5H5qYWB6ZTAyM0C8hpfcSVLB9/a3qnH1GGvIJ+FEbpEs4s/HfErYe/M5qZeLjwmESR5fFm3lXEw==",
+      "dependencies": {
+        "@iconify/types": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/cyberalien"
+      },
+      "peerDependencies": {
+        "vue": ">=3.0.0"
+      }
+    },
     "node_modules/@ioredis/commands": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.2.0.tgz",
@@ -935,6 +1071,23 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@koa/router": {
+      "version": "12.0.2",
+      "resolved": "https://registry.npmjs.org/@koa/router/-/router-12.0.2.tgz",
+      "integrity": "sha512-sYcHglGKTxGF+hQ6x67xDfkE9o+NhVlRHBqq6gLywaMc6CojK/5vFZByphdonKinYlMLkEkacm+HEse9HzwgTA==",
+      "deprecated": "Please upgrade to v15 or higher. All reported bugs in this version are fixed in newer releases, dependencies have been updated, and security has been improved.",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.3.4",
+        "http-errors": "^2.0.0",
+        "koa-compose": "^4.1.0",
+        "methods": "^1.1.2",
+        "path-to-regexp": "^6.3.0"
+      },
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/@kwsites/file-exists": {
@@ -1301,6 +1454,27 @@
         "devtools-wizard": "cli.mjs"
       }
     },
+    "node_modules/@nuxt/icon": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@nuxt/icon/-/icon-1.15.0.tgz",
+      "integrity": "sha512-kA0rxqr1B601zNJNcOXera8CyYcxUCEcT7dXEC7rwAz71PRCN5emf7G656eKEQgtqrD4JSj6NQqWDgrmFcf/GQ==",
+      "dependencies": {
+        "@iconify/collections": "^1.0.563",
+        "@iconify/types": "^2.0.0",
+        "@iconify/utils": "^2.3.0",
+        "@iconify/vue": "^5.0.0",
+        "@nuxt/devtools-kit": "^2.5.0",
+        "@nuxt/kit": "^3.17.5",
+        "consola": "^3.4.2",
+        "local-pkg": "^1.1.1",
+        "mlly": "^1.7.4",
+        "ohash": "^2.0.11",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinyglobby": "^0.2.14"
+      }
+    },
     "node_modules/@nuxt/kit": {
       "version": "3.17.5",
       "resolved": "https://registry.npmjs.org/@nuxt/kit/-/kit-3.17.5.tgz",
@@ -1417,6 +1591,30 @@
       },
       "peerDependencies": {
         "vue": "^3.3.4"
+      }
+    },
+    "node_modules/@nuxtjs/tailwindcss": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/@nuxtjs/tailwindcss/-/tailwindcss-6.14.0.tgz",
+      "integrity": "sha512-30RyDK++LrUVRgc2A85MktGWIZoRQgeQKjE4CjjD64OXNozyl+4ScHnnYgqVToMM6Ch2ZG2W4wV2J0EN6F0zkQ==",
+      "dev": true,
+      "dependencies": {
+        "@nuxt/kit": "^3.16.0",
+        "autoprefixer": "^10.4.20",
+        "c12": "^3.0.2",
+        "consola": "^3.4.0",
+        "defu": "^6.1.4",
+        "h3": "^1.15.1",
+        "klona": "^2.0.6",
+        "ohash": "^2.0.11",
+        "pathe": "^2.0.3",
+        "pkg-types": "^2.1.0",
+        "postcss": "^8.5.3",
+        "postcss-nesting": "^13.0.1",
+        "tailwind-config-viewer": "^2.0.4",
+        "tailwindcss": "~3.4.17",
+        "ufo": "^1.5.4",
+        "unctx": "^2.4.1"
       }
     },
     "node_modules/@oxc-parser/binding-darwin-arm64": {
@@ -2910,18 +3108,6 @@
       "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.16.tgz",
       "integrity": "sha512-c/0fWy3Jw6Z8L9FmTyYfkpM5zklnqqa9+a6dz3DvONRKW2NEbh46BP0FHuLFSWi2TnQEtp91Z6zOWNrU6QiyPg=="
     },
-    "node_modules/@vuetify/loader-shared": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@vuetify/loader-shared/-/loader-shared-2.1.0.tgz",
-      "integrity": "sha512-dNE6Ceym9ijFsmJKB7YGW0cxs7xbYV8+1LjU6jd4P14xOt/ji4Igtgzt0rJFbxu+ZhAzqz853lhB0z8V9Dy9cQ==",
-      "dependencies": {
-        "upath": "^2.0.1"
-      },
-      "peerDependencies": {
-        "vue": "^3.0.0",
-        "vuetify": "^3.0.0"
-      }
-    },
     "node_modules/@whatwg-node/disposablestack": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/@whatwg-node/disposablestack/-/disposablestack-0.0.6.tgz",
@@ -3009,6 +3195,40 @@
         "node": ">=6.5"
       }
     },
+    "node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "dev": true,
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/accepts/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/accepts/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -3065,6 +3285,12 @@
       "engines": {
         "node": ">=14"
       }
+    },
+    "node_modules/any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+      "dev": true
     },
     "node_modules/anymatch": {
       "version": "3.1.3",
@@ -3134,6 +3360,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/arg": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
+      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
+      "dev": true
+    },
     "node_modules/ast-kit": {
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/ast-kit/-/ast-kit-1.4.3.tgz",
@@ -3178,6 +3410,15 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/async-sema/-/async-sema-3.1.1.tgz",
       "integrity": "sha512-tLRNUXati5MFePdAk8dw7Qt7DpxPB60ofAgn8WRhW6a2rcimZnYBP9oxHiv0OHy+Wz7kPMG+t4LGdt31+4EmGg=="
+    },
+    "node_modules/at-least-node": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
+      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 4.0.0"
+      }
     },
     "node_modules/autoprefixer": {
       "version": "10.4.21",
@@ -3249,6 +3490,18 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/binary-extensions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/bindings": {
       "version": "1.5.0",
@@ -3382,20 +3635,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/bundle-require": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/bundle-require/-/bundle-require-5.1.0.tgz",
-      "integrity": "sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==",
-      "dependencies": {
-        "load-tsconfig": "^0.2.3"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "peerDependencies": {
-        "esbuild": ">=0.18"
-      }
-    },
     "node_modules/c12": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/c12/-/c12-3.0.4.tgz",
@@ -3429,6 +3668,40 @@
       "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/cache-content-type": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/cache-content-type/-/cache-content-type-1.0.1.tgz",
+      "integrity": "sha512-IKufZ1o4Ut42YUrZSo8+qnMTrFuKkvyoLXUywKz9GJ5BrhOFGhLdkx9sG4KAnVvbY6kEcSFjLQul+DVmBm2bgA==",
+      "dev": true,
+      "dependencies": {
+        "mime-types": "^2.1.18",
+        "ylru": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/cache-content-type/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cache-content-type/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/call-bind-apply-helpers": {
@@ -3466,6 +3739,15 @@
         "node": "*"
       }
     },
+    "node_modules/camelcase-css": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
+      "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/caniuse-api": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/caniuse-api/-/caniuse-api-3.0.0.tgz",
@@ -3495,6 +3777,61 @@
           "url": "https://github.com/sponsors/ai"
         }
       ]
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chalk/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/chalk/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/chalk/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/chokidar": {
       "version": "4.0.3",
@@ -3641,6 +3978,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/co": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "integrity": "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==",
+      "dev": true,
+      "engines": {
+        "iojs": ">= 1.0.0",
+        "node": ">= 0.12.0"
+      }
+    },
     "node_modules/color": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/color/-/color-3.2.1.tgz",
@@ -3740,6 +4087,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true
+    },
     "node_modules/confbox": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.2.tgz",
@@ -3751,6 +4104,27 @@
       "integrity": "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==",
       "engines": {
         "node": "^14.18.0 || >=16.10.0"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "dev": true,
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/convert-source-map": {
@@ -3770,6 +4144,19 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-2.0.0.tgz",
       "integrity": "sha512-RAj4E421UYRgqokKUmotqAwuplYw15qtdXfY+hGzgCJ/MBjCVZcSoHK/kH9kocfjRjcDME7IiDWR/1WX1TM2Pg=="
+    },
+    "node_modules/cookies": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/cookies/-/cookies-0.9.1.tgz",
+      "integrity": "sha512-TG2hpqe4ELx54QER/S3HQ9SRVnQnGBtKUz5bLQWtYAQ+o6GpgMs6sYUvaiJjVxb+UXwhRhAEP3m7LbsIZ77Hmw==",
+      "dev": true,
+      "dependencies": {
+        "depd": "~2.0.0",
+        "keygrip": "~1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/copy-anything": {
       "version": "3.0.5",
@@ -4120,6 +4507,12 @@
         "callsite": "^1.0.0"
       }
     },
+    "node_modules/deep-equal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+      "integrity": "sha512-bHtC0iYvWhyaTzvV3CZgPeZQqCOBGyGsVV7v4eevpdkLHfiSrXUdBG+qAuSz4RI70sszvjQ1QSZ98An1yNwpSw==",
+      "dev": true
+    },
     "node_modules/deepmerge": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
@@ -4167,6 +4560,12 @@
       "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.4.tgz",
       "integrity": "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg=="
     },
+    "node_modules/delegates": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+      "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
+      "dev": true
+    },
     "node_modules/denque": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
@@ -4187,6 +4586,16 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/destr/-/destr-2.0.5.tgz",
       "integrity": "sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA=="
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
     },
     "node_modules/detect-libc": {
       "version": "1.0.3",
@@ -4327,6 +4736,12 @@
       "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.1.1.tgz",
       "integrity": "sha512-maua5KUiapvEwiEAe+XnlZ3Rh0GD+qI1J/nb9vrJc3muPXvcF/8gXYTWF76+5DAqHyDUtOIImEuo0YKE9mshVw=="
     },
+    "node_modules/didyoumean": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
+      "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
+      "dev": true
+    },
     "node_modules/diff": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.2.tgz",
@@ -4334,6 +4749,12 @@
       "engines": {
         "node": ">=0.3.1"
       }
+    },
+    "node_modules/dlv": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
+      "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
+      "dev": true
     },
     "node_modules/dom-serializer": {
       "version": "2.0.0",
@@ -4977,6 +5398,27 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/fs-extra": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "dev": true,
+      "dependencies": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -5004,6 +5446,15 @@
       "integrity": "sha512-trLf4SzuuUxfusZADLINj+dE8clK1frKdmqiJNb1Es75fmI5oY6X2mxLVUciLLjxqw/xr72Dhy+lER6dGd02FQ==",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/generator-function": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz",
+      "integrity": "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/gensync": {
@@ -5089,6 +5540,8 @@
       "version": "4.10.1",
       "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.10.1.tgz",
       "integrity": "sha512-auHyJ4AgMz7vgS8Hp3N6HXSmlMdUyhSUrfBF16w153rxtLIEOE+HGqaBppczZvnHLqQJfiHotCYpNhl0lUROFQ==",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "resolve-pkg-maps": "^1.0.0"
       },
@@ -5276,10 +5729,34 @@
       "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-1.2.2.tgz",
       "integrity": "sha512-+W7VmiVINB+ywl1HGXJXmrqkOhpKrIiVZV6tQuV54ZyQC7MMuBt81Vc336GMLoHBq5hV/F9eXgt5Mnx0Rha5Fg=="
     },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/has-symbols": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -5318,6 +5795,53 @@
       "version": "10.4.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="
+    },
+    "node_modules/http-assert": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/http-assert/-/http-assert-1.5.0.tgz",
+      "integrity": "sha512-uPpH7OKX4H25hBmU6G1jWNaqJGpTXxey+YOUizJUAgu0AjLUeC8D73hTrhvDS5D+GJN1DN1+hhc/eF/wpxtp0w==",
+      "dev": true,
+      "dependencies": {
+        "deep-equal": "~1.0.1",
+        "http-errors": "~1.8.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/http-assert/node_modules/depd": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/http-assert/node_modules/http-errors": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
+      "integrity": "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==",
+      "dev": true,
+      "dependencies": {
+        "depd": "~1.1.2",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": ">= 1.5.0 < 2",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/http-assert/node_modules/statuses": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+      "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/http-errors": {
       "version": "2.0.0",
@@ -5408,434 +5932,6 @@
       "resolved": "https://registry.npmjs.org/image-meta/-/image-meta-0.2.1.tgz",
       "integrity": "sha512-K6acvFaelNxx8wc2VjbIzXKDVB0Khs0QT35U6NkGfTdCmjLNcO2945m7RFNR9/RPVFm48hq7QPzK8uGH18HCGw=="
     },
-    "node_modules/importx": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/importx/-/importx-0.4.4.tgz",
-      "integrity": "sha512-Lo1pukzAREqrBnnHC+tj+lreMTAvyxtkKsMxLY8H15M/bvLl54p3YuoTI70Tz7Il0AsgSlD7Lrk/FaApRcBL7w==",
-      "dependencies": {
-        "bundle-require": "^5.0.0",
-        "debug": "^4.3.6",
-        "esbuild": "^0.20.2 || ^0.21.0 || ^0.22.0 || ^0.23.0",
-        "jiti": "2.0.0-beta.3",
-        "jiti-v1": "npm:jiti@^1.21.6",
-        "pathe": "^1.1.2",
-        "tsx": "^4.19.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/antfu"
-      }
-    },
-    "node_modules/importx/node_modules/@esbuild/aix-ppc64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.23.1.tgz",
-      "integrity": "sha512-6VhYk1diRqrhBAqpJEdjASR/+WVRtfjpqKuNw11cLiaWpAT/Uu+nokB+UJnevzy/P9C/ty6AOe0dwueMrGh/iQ==",
-      "cpu": [
-        "ppc64"
-      ],
-      "optional": true,
-      "os": [
-        "aix"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/importx/node_modules/@esbuild/android-arm": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.23.1.tgz",
-      "integrity": "sha512-uz6/tEy2IFm9RYOyvKl88zdzZfwEfKZmnX9Cj1BHjeSGNuGLuMD1kR8y5bteYmwqKm1tj8m4cb/aKEorr6fHWQ==",
-      "cpu": [
-        "arm"
-      ],
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/importx/node_modules/@esbuild/android-arm64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.23.1.tgz",
-      "integrity": "sha512-xw50ipykXcLstLeWH7WRdQuysJqejuAGPd30vd1i5zSyKK3WE+ijzHmLKxdiCMtH1pHz78rOg0BKSYOSB/2Khw==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/importx/node_modules/@esbuild/android-x64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.23.1.tgz",
-      "integrity": "sha512-nlN9B69St9BwUoB+jkyU090bru8L0NA3yFvAd7k8dNsVH8bi9a8cUAUSEcEEgTp2z3dbEDGJGfP6VUnkQnlReg==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/importx/node_modules/@esbuild/darwin-arm64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.23.1.tgz",
-      "integrity": "sha512-YsS2e3Wtgnw7Wq53XXBLcV6JhRsEq8hkfg91ESVadIrzr9wO6jJDMZnCQbHm1Guc5t/CdDiFSSfWP58FNuvT3Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/importx/node_modules/@esbuild/darwin-x64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.23.1.tgz",
-      "integrity": "sha512-aClqdgTDVPSEGgoCS8QDG37Gu8yc9lTHNAQlsztQ6ENetKEO//b8y31MMu2ZaPbn4kVsIABzVLXYLhCGekGDqw==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/importx/node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.23.1.tgz",
-      "integrity": "sha512-h1k6yS8/pN/NHlMl5+v4XPfikhJulk4G+tKGFIOwURBSFzE8bixw1ebjluLOjfwtLqY0kewfjLSrO6tN2MgIhA==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/importx/node_modules/@esbuild/freebsd-x64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.23.1.tgz",
-      "integrity": "sha512-lK1eJeyk1ZX8UklqFd/3A60UuZ/6UVfGT2LuGo3Wp4/z7eRTRYY+0xOu2kpClP+vMTi9wKOfXi2vjUpO1Ro76g==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/importx/node_modules/@esbuild/linux-arm": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.23.1.tgz",
-      "integrity": "sha512-CXXkzgn+dXAPs3WBwE+Kvnrf4WECwBdfjfeYHpMeVxWE0EceB6vhWGShs6wi0IYEqMSIzdOF1XjQ/Mkm5d7ZdQ==",
-      "cpu": [
-        "arm"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/importx/node_modules/@esbuild/linux-arm64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.23.1.tgz",
-      "integrity": "sha512-/93bf2yxencYDnItMYV/v116zff6UyTjo4EtEQjUBeGiVpMmffDNUyD9UN2zV+V3LRV3/on4xdZ26NKzn6754g==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/importx/node_modules/@esbuild/linux-ia32": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.23.1.tgz",
-      "integrity": "sha512-VTN4EuOHwXEkXzX5nTvVY4s7E/Krz7COC8xkftbbKRYAl96vPiUssGkeMELQMOnLOJ8k3BY1+ZY52tttZnHcXQ==",
-      "cpu": [
-        "ia32"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/importx/node_modules/@esbuild/linux-loong64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.23.1.tgz",
-      "integrity": "sha512-Vx09LzEoBa5zDnieH8LSMRToj7ir/Jeq0Gu6qJ/1GcBq9GkfoEAoXvLiW1U9J1qE/Y/Oyaq33w5p2ZWrNNHNEw==",
-      "cpu": [
-        "loong64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/importx/node_modules/@esbuild/linux-mips64el": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.23.1.tgz",
-      "integrity": "sha512-nrFzzMQ7W4WRLNUOU5dlWAqa6yVeI0P78WKGUo7lg2HShq/yx+UYkeNSE0SSfSure0SqgnsxPvmAUu/vu0E+3Q==",
-      "cpu": [
-        "mips64el"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/importx/node_modules/@esbuild/linux-ppc64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.23.1.tgz",
-      "integrity": "sha512-dKN8fgVqd0vUIjxuJI6P/9SSSe/mB9rvA98CSH2sJnlZ/OCZWO1DJvxj8jvKTfYUdGfcq2dDxoKaC6bHuTlgcw==",
-      "cpu": [
-        "ppc64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/importx/node_modules/@esbuild/linux-riscv64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.23.1.tgz",
-      "integrity": "sha512-5AV4Pzp80fhHL83JM6LoA6pTQVWgB1HovMBsLQ9OZWLDqVY8MVobBXNSmAJi//Csh6tcY7e7Lny2Hg1tElMjIA==",
-      "cpu": [
-        "riscv64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/importx/node_modules/@esbuild/linux-s390x": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.23.1.tgz",
-      "integrity": "sha512-9ygs73tuFCe6f6m/Tb+9LtYxWR4c9yg7zjt2cYkjDbDpV/xVn+68cQxMXCjUpYwEkze2RcU/rMnfIXNRFmSoDw==",
-      "cpu": [
-        "s390x"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/importx/node_modules/@esbuild/linux-x64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.23.1.tgz",
-      "integrity": "sha512-EV6+ovTsEXCPAp58g2dD68LxoP/wK5pRvgy0J/HxPGB009omFPv3Yet0HiaqvrIrgPTBuC6wCH1LTOY91EO5hQ==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/importx/node_modules/@esbuild/netbsd-x64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.23.1.tgz",
-      "integrity": "sha512-aevEkCNu7KlPRpYLjwmdcuNz6bDFiE7Z8XC4CPqExjTvrHugh28QzUXVOZtiYghciKUacNktqxdpymplil1beA==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/importx/node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.23.1.tgz",
-      "integrity": "sha512-3x37szhLexNA4bXhLrCC/LImN/YtWis6WXr1VESlfVtVeoFJBRINPJ3f0a/6LV8zpikqoUg4hyXw0sFBt5Cr+Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/importx/node_modules/@esbuild/openbsd-x64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.23.1.tgz",
-      "integrity": "sha512-aY2gMmKmPhxfU+0EdnN+XNtGbjfQgwZj43k8G3fyrDM/UdZww6xrWxmDkuz2eCZchqVeABjV5BpildOrUbBTqA==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/importx/node_modules/@esbuild/sunos-x64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.23.1.tgz",
-      "integrity": "sha512-RBRT2gqEl0IKQABT4XTj78tpk9v7ehp+mazn2HbUeZl1YMdaGAQqhapjGTCe7uw7y0frDi4gS0uHzhvpFuI1sA==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/importx/node_modules/@esbuild/win32-arm64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.23.1.tgz",
-      "integrity": "sha512-4O+gPR5rEBe2FpKOVyiJ7wNDPA8nGzDuJ6gN4okSA1gEOYZ67N8JPk58tkWtdtPeLz7lBnY6I5L3jdsr3S+A6A==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/importx/node_modules/@esbuild/win32-ia32": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.23.1.tgz",
-      "integrity": "sha512-BcaL0Vn6QwCwre3Y717nVHZbAa4UBEigzFm6VdsVdT/MbZ38xoj1X9HPkZhbmaBGUD1W8vxAfffbDe8bA6AKnQ==",
-      "cpu": [
-        "ia32"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/importx/node_modules/@esbuild/win32-x64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.23.1.tgz",
-      "integrity": "sha512-BHpFFeslkWrXWyUPnbKm+xYYVYruCinGcftSBaa8zoF9hZO4BcSCFUvHVTtzpIY6YzUnYtuEhZ+C9iEXjxnasg==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/importx/node_modules/esbuild": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.23.1.tgz",
-      "integrity": "sha512-VVNz/9Sa0bs5SELtn3f7qhJCDPCF5oMEl5cO9/SSinpE9hbPVvxbd572HH5AKiP7WD8INO53GgfDDhRjkylHEg==",
-      "hasInstallScript": true,
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.23.1",
-        "@esbuild/android-arm": "0.23.1",
-        "@esbuild/android-arm64": "0.23.1",
-        "@esbuild/android-x64": "0.23.1",
-        "@esbuild/darwin-arm64": "0.23.1",
-        "@esbuild/darwin-x64": "0.23.1",
-        "@esbuild/freebsd-arm64": "0.23.1",
-        "@esbuild/freebsd-x64": "0.23.1",
-        "@esbuild/linux-arm": "0.23.1",
-        "@esbuild/linux-arm64": "0.23.1",
-        "@esbuild/linux-ia32": "0.23.1",
-        "@esbuild/linux-loong64": "0.23.1",
-        "@esbuild/linux-mips64el": "0.23.1",
-        "@esbuild/linux-ppc64": "0.23.1",
-        "@esbuild/linux-riscv64": "0.23.1",
-        "@esbuild/linux-s390x": "0.23.1",
-        "@esbuild/linux-x64": "0.23.1",
-        "@esbuild/netbsd-x64": "0.23.1",
-        "@esbuild/openbsd-arm64": "0.23.1",
-        "@esbuild/openbsd-x64": "0.23.1",
-        "@esbuild/sunos-x64": "0.23.1",
-        "@esbuild/win32-arm64": "0.23.1",
-        "@esbuild/win32-ia32": "0.23.1",
-        "@esbuild/win32-x64": "0.23.1"
-      }
-    },
-    "node_modules/importx/node_modules/jiti": {
-      "version": "2.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.0.0-beta.3.tgz",
-      "integrity": "sha512-pmfRbVRs/7khFrSAYnSiJ8C0D5GvzkE4Ey2pAvUcJsw1ly/p+7ut27jbJrjY79BpAJQJ4gXYFtK6d1Aub+9baQ==",
-      "bin": {
-        "jiti": "lib/jiti-cli.mjs"
-      }
-    },
-    "node_modules/importx/node_modules/pathe": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
-      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ=="
-    },
     "node_modules/impound": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/impound/-/impound-1.0.0.tgz",
@@ -5865,6 +5961,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "dev": true,
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "node_modules/inherits": {
@@ -5915,6 +6022,18 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
       "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
+    },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/is-builtin-module": {
       "version": "3.2.1",
@@ -5972,6 +6091,25 @@
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-generator-function": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz",
+      "integrity": "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==",
+      "dev": true,
+      "dependencies": {
+        "call-bound": "^1.0.4",
+        "generator-function": "^2.0.0",
+        "get-proto": "^1.0.1",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-glob": {
@@ -6055,6 +6193,24 @@
       "integrity": "sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==",
       "dependencies": {
         "@types/estree": "*"
+      }
+    },
+    "node_modules/is-regex": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
+      "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
+      "dev": true,
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-ssh": {
@@ -6166,15 +6322,6 @@
         "jiti": "lib/jiti-cli.mjs"
       }
     },
-    "node_modules/jiti-v1": {
-      "name": "jiti",
-      "version": "1.21.7",
-      "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
-      "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
-      "bin": {
-        "jiti": "bin/jiti.js"
-      }
-    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -6202,6 +6349,18 @@
         "node": ">=6"
       }
     },
+    "node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "dev": true,
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
     "node_modules/junk": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/junk/-/junk-4.0.1.tgz",
@@ -6219,6 +6378,18 @@
       "integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/keygrip": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/keygrip/-/keygrip-1.1.0.tgz",
+      "integrity": "sha512-iYSchDJ+liQ8iwbSI2QqsQOvqv58eJCEanyJPJi+Khyu8smkcKSFUCbPwzFcL7YVtZ6eONjqRX/38caJ7QjRAQ==",
+      "dev": true,
+      "dependencies": {
+        "tsscmp": "1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/kleur": {
@@ -6241,6 +6412,186 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/knitwork/-/knitwork-1.2.0.tgz",
       "integrity": "sha512-xYSH7AvuQ6nXkq42x0v5S8/Iry+cfulBz/DJQzhIyESdLD7425jXsPy4vn5cCXU+HhRN2kVw51Vd1K6/By4BQg=="
+    },
+    "node_modules/koa": {
+      "version": "2.16.4",
+      "resolved": "https://registry.npmjs.org/koa/-/koa-2.16.4.tgz",
+      "integrity": "sha512-3An0GCLDSR34tsCO4H8Tef8Pp2ngtaZDAZnsWJYelqXUK5wyiHvGItgK/xcSkmHLSTn1Jcho1mRQs2ehRzvKKw==",
+      "dev": true,
+      "dependencies": {
+        "accepts": "^1.3.5",
+        "cache-content-type": "^1.0.0",
+        "content-disposition": "~0.5.2",
+        "content-type": "^1.0.4",
+        "cookies": "~0.9.0",
+        "debug": "^4.3.2",
+        "delegates": "^1.0.0",
+        "depd": "^2.0.0",
+        "destroy": "^1.0.4",
+        "encodeurl": "^1.0.2",
+        "escape-html": "^1.0.3",
+        "fresh": "~0.5.2",
+        "http-assert": "^1.3.0",
+        "http-errors": "^1.6.3",
+        "is-generator-function": "^1.0.7",
+        "koa-compose": "^4.1.0",
+        "koa-convert": "^2.0.0",
+        "on-finished": "^2.3.0",
+        "only": "~0.0.2",
+        "parseurl": "^1.3.2",
+        "statuses": "^1.5.0",
+        "type-is": "^1.6.16",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": "^4.8.4 || ^6.10.1 || ^7.10.1 || >= 8.1.4"
+      }
+    },
+    "node_modules/koa-compose": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/koa-compose/-/koa-compose-4.1.0.tgz",
+      "integrity": "sha512-8ODW8TrDuMYvXRwra/Kh7/rJo9BtOfPc6qO8eAfC80CnCvSjSl0bkRM24X6/XBBEyj0v1nRUQ1LyOy3dbqOWXw==",
+      "dev": true
+    },
+    "node_modules/koa-convert": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/koa-convert/-/koa-convert-2.0.0.tgz",
+      "integrity": "sha512-asOvN6bFlSnxewce2e/DK3p4tltyfC4VM7ZwuTuepI7dEQVcvpyFuBcEARu1+Hxg8DIwytce2n7jrZtRlPrARA==",
+      "dev": true,
+      "dependencies": {
+        "co": "^4.6.0",
+        "koa-compose": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/koa-send": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/koa-send/-/koa-send-5.0.1.tgz",
+      "integrity": "sha512-tmcyQ/wXXuxpDxyNXv5yNNkdAMdFRqwtegBXUaowiQzUKqJehttS0x2j0eOZDQAyloAth5w6wwBImnFzkUz3pQ==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.1.1",
+        "http-errors": "^1.7.3",
+        "resolve-path": "^1.4.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/koa-send/node_modules/depd": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/koa-send/node_modules/http-errors": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
+      "integrity": "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==",
+      "dev": true,
+      "dependencies": {
+        "depd": "~1.1.2",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": ">= 1.5.0 < 2",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/koa-send/node_modules/statuses": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+      "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/koa-static": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/koa-static/-/koa-static-5.0.0.tgz",
+      "integrity": "sha512-UqyYyH5YEXaJrf9S8E23GoJFQZXkBVJ9zYYMPGz919MSX1KuvAcycIuS0ci150HCoPf4XQVhQ84Qf8xRPWxFaQ==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^3.1.0",
+        "koa-send": "^5.0.0"
+      },
+      "engines": {
+        "node": ">= 7.6.0"
+      }
+    },
+    "node_modules/koa-static/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/koa/node_modules/encodeurl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/koa/node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/koa/node_modules/http-errors": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
+      "integrity": "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==",
+      "dev": true,
+      "dependencies": {
+        "depd": "~1.1.2",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": ">= 1.5.0 < 2",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/koa/node_modules/http-errors/node_modules/depd": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/koa/node_modules/statuses": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+      "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/kolorist": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/kolorist/-/kolorist-1.8.0.tgz",
+      "integrity": "sha512-Y+60/zizpJ3HRH8DCss+q95yr6145JXZo46OTpFvDZWLfRCE4qChOyk1b26nMaNpfHHgxagk9dXT5OP0Tfe+dQ=="
     },
     "node_modules/kuler": {
       "version": "2.0.0",
@@ -6321,6 +6672,12 @@
         "url": "https://github.com/sponsors/antonk52"
       }
     },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true
+    },
     "node_modules/listhen": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/listhen/-/listhen-1.9.0.tgz",
@@ -6354,14 +6711,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
       "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ=="
-    },
-    "node_modules/load-tsconfig": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/load-tsconfig/-/load-tsconfig-0.2.5.tgz",
-      "integrity": "sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==",
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      }
     },
     "node_modules/local-pkg": {
       "version": "1.1.1",
@@ -6505,6 +6854,15 @@
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.30.tgz",
       "integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA=="
     },
+    "node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/merge-options": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-3.0.4.tgz",
@@ -6527,6 +6885,15 @@
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/micro-api-client": {
@@ -6720,6 +7087,17 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
+    "node_modules/mz": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "dev": true,
+      "dependencies": {
+        "any-promise": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "thenify-all": "^1.0.0"
+      }
+    },
     "node_modules/nanoid": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.5.tgz",
@@ -6741,6 +7119,15 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/nanotar/-/nanotar-0.2.0.tgz",
       "integrity": "sha512-9ca1h0Xjvo9bEkE4UOxgAzLV0jHKe6LMaxo37ND2DAhhAtd0j8pR1Wxz+/goMrZO8AEZTWCmyaOsFI/W5AdpCQ=="
+    },
+    "node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/netlify": {
       "version": "13.3.5",
@@ -7173,6 +7560,24 @@
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
       "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA=="
     },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-hash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/object-inspect": {
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
@@ -7250,6 +7655,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/only": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/only/-/only-0.0.2.tgz",
+      "integrity": "sha512-Fvw+Jemq5fjjyWz6CpKx6w9s7xxqo3+JCyM0WXWeCSOboZ8ABkyvP8ID4CZuChA/wxSx+XSJmdOm8rGVyJ1hdQ==",
+      "dev": true
     },
     "node_modules/open": {
       "version": "8.4.2",
@@ -7470,6 +7881,15 @@
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
     },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
@@ -7502,6 +7922,12 @@
       "version": "10.4.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="
+    },
+    "node_modules/path-to-regexp": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "dev": true
     },
     "node_modules/path-type": {
       "version": "6.0.0",
@@ -7545,6 +7971,24 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/pify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/pirates": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+      "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/pkg-types": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.1.0.tgz",
@@ -7553,6 +7997,19 @@
         "confbox": "^0.2.1",
         "exsolve": "^1.0.1",
         "pathe": "^2.0.3"
+      }
+    },
+    "node_modules/portfinder": {
+      "version": "1.0.38",
+      "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.38.tgz",
+      "integrity": "sha512-rEwq/ZHlJIKw++XtLAO8PPuOQA/zaPJOZJ37BVuN97nLpMJeuDVLVGRwbFoBgLudgdTMP2hdRJP++H+8QOA3vg==",
+      "dev": true,
+      "dependencies": {
+        "async": "^3.2.6",
+        "debug": "^4.3.6"
+      },
+      "engines": {
+        "node": ">= 10.12"
       }
     },
     "node_modules/postcss": {
@@ -7676,6 +8133,111 @@
         "postcss": "^8.4.32"
       }
     },
+    "node_modules/postcss-import": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
+      "integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
+      "dev": true,
+      "dependencies": {
+        "postcss-value-parser": "^4.0.0",
+        "read-cache": "^1.0.0",
+        "resolve": "^1.1.7"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.0.0"
+      }
+    },
+    "node_modules/postcss-import/node_modules/resolve": {
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "dev": true,
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/postcss-js": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.1.0.tgz",
+      "integrity": "sha512-oIAOTqgIo7q2EOwbhb8UalYePMvYoIeRY2YKntdpFQXNosSu3vLrniGgmH9OKs/qAkfoj5oB3le/7mINW1LCfw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "camelcase-css": "^2.0.1"
+      },
+      "engines": {
+        "node": "^12 || ^14 || >= 16"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4.21"
+      }
+    },
+    "node_modules/postcss-load-config": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-6.0.1.tgz",
+      "integrity": "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "lilconfig": "^3.1.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "jiti": ">=1.21.0",
+        "postcss": ">=8.0.9",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/postcss-merge-longhand": {
       "version": "7.0.5",
       "resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-7.0.5.tgz",
@@ -7767,6 +8329,71 @@
       },
       "peerDependencies": {
         "postcss": "^8.4.32"
+      }
+    },
+    "node_modules/postcss-nested": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.2.0.tgz",
+      "integrity": "sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "postcss-selector-parser": "^6.1.1"
+      },
+      "engines": {
+        "node": ">=12.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.14"
+      }
+    },
+    "node_modules/postcss-nested/node_modules/postcss-selector-parser": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.4.tgz",
+      "integrity": "sha512-bIoJLOmjCO1S9XdY/DcnR5hJxvrDir1PbGChrzXG3vw0/FOliy/fA3dmdhQ441kah4gKv+TwckGzex6wNS5cnQ==",
+      "dev": true,
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postcss-nesting": {
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-nesting/-/postcss-nesting-13.0.2.tgz",
+      "integrity": "sha512-1YCI290TX+VP0U/K/aFxzHzQWHWURL+CtHMSbex1lCdpXD1SoR2sYuxDu5aNI9lPoXpKTCggFZiDJbwylU0LEQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "dependencies": {
+        "@csstools/selector-resolve-nested": "^3.1.0",
+        "@csstools/selector-specificity": "^5.0.0",
+        "postcss-selector-parser": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
       }
     },
     "node_modules/postcss-normalize-charset": {
@@ -8185,6 +8812,15 @@
         "destr": "^2.0.3"
       }
     },
+    "node_modules/read-cache": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
+      "integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
+      "dev": true,
+      "dependencies": {
+        "pify": "^2.3.0"
+      }
+    },
     "node_modules/read-package-up": {
       "version": "11.0.0",
       "resolved": "https://registry.npmjs.org/read-package-up/-/read-package-up-11.0.0.tgz",
@@ -8289,6 +8925,66 @@
       "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
       "integrity": "sha512-/hS+Y0u3aOfIETiaiirUFwDBDzmXPvO+jAfKTitUngIPzdKc6Z0LoFjM/CK5PL4C+eKwHohlHAb6H0VFfmmUsw=="
     },
+    "node_modules/replace-in-file": {
+      "version": "6.3.5",
+      "resolved": "https://registry.npmjs.org/replace-in-file/-/replace-in-file-6.3.5.tgz",
+      "integrity": "sha512-arB9d3ENdKva2fxRnSjwBEXfK1npgyci7ZZuwysgAp7ORjHSyxz6oqIjTEv8R0Ydl4Ll7uOAZXL4vbkhGIizCg==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^4.1.2",
+        "glob": "^7.2.0",
+        "yargs": "^17.2.1"
+      },
+      "bin": {
+        "replace-in-file": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/replace-in-file/node_modules/brace-expansion": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/replace-in-file/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/replace-in-file/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -8326,10 +9022,70 @@
         "node": ">=8"
       }
     },
+    "node_modules/resolve-path": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/resolve-path/-/resolve-path-1.4.0.tgz",
+      "integrity": "sha512-i1xevIst/Qa+nA9olDxLWnLk8YZbi8R/7JPbCMcgyWaFR6bKWaexgJgEB5oc2PKMjYdrHynyz0NY+if+H98t1w==",
+      "dev": true,
+      "dependencies": {
+        "http-errors": "~1.6.2",
+        "path-is-absolute": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/resolve-path/node_modules/depd": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/resolve-path/node_modules/http-errors": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+      "integrity": "sha512-lks+lVC8dgGyh97jxvxeYTWQFvh4uw4yC12gVl63Cg30sjPX4wuGcdkICVXDAESr6OJGjqGA8Iz5mkeN6zlD7A==",
+      "dev": true,
+      "dependencies": {
+        "depd": "~1.1.2",
+        "inherits": "2.0.3",
+        "setprototypeof": "1.1.0",
+        "statuses": ">= 1.4.0 < 2"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/resolve-path/node_modules/inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw==",
+      "dev": true
+    },
+    "node_modules/resolve-path/node_modules/setprototypeof": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
+      "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
+      "dev": true
+    },
+    "node_modules/resolve-path/node_modules/statuses": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+      "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/resolve-pkg-maps": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
       "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "optional": true,
+      "peer": true,
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
@@ -8471,6 +9227,23 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/safe-regex-test": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
+      "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
+      "dev": true,
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-regex": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/safe-stable-stringify": {
       "version": "2.5.0",
@@ -8967,6 +9740,37 @@
         "postcss": "^8.4.32"
       }
     },
+    "node_modules/sucrase": {
+      "version": "3.35.1",
+      "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
+      "integrity": "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.2",
+        "commander": "^4.0.0",
+        "lines-and-columns": "^1.1.6",
+        "mz": "^2.7.0",
+        "pirates": "^4.0.1",
+        "tinyglobby": "^0.2.11",
+        "ts-interface-checker": "^0.1.9"
+      },
+      "bin": {
+        "sucrase": "bin/sucrase",
+        "sucrase-node": "bin/sucrase-node"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/sucrase/node_modules/commander": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/superjson": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/superjson/-/superjson-2.2.2.tgz",
@@ -9041,6 +9845,236 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/tailwind-config-viewer": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/tailwind-config-viewer/-/tailwind-config-viewer-2.0.4.tgz",
+      "integrity": "sha512-icvcmdMmt9dphvas8wL40qttrHwAnW3QEN4ExJ2zICjwRsPj7gowd1cOceaWG3IfTuM/cTNGQcx+bsjMtmV+cw==",
+      "dev": true,
+      "dependencies": {
+        "@koa/router": "^12.0.1",
+        "commander": "^6.0.0",
+        "fs-extra": "^9.0.1",
+        "koa": "^2.14.2",
+        "koa-static": "^5.0.0",
+        "open": "^7.0.4",
+        "portfinder": "^1.0.26",
+        "replace-in-file": "^6.1.0"
+      },
+      "bin": {
+        "tailwind-config-viewer": "cli/index.js",
+        "tailwindcss-config-viewer": "cli/index.js"
+      },
+      "engines": {
+        "node": ">=13"
+      },
+      "peerDependencies": {
+        "tailwindcss": "1 || 2 || 2.0.1-compat || 3"
+      }
+    },
+    "node_modules/tailwind-config-viewer/node_modules/commander": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
+      "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/tailwind-config-viewer/node_modules/is-docker": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+      "dev": true,
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/tailwind-config-viewer/node_modules/is-wsl": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "dev": true,
+      "dependencies": {
+        "is-docker": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tailwind-config-viewer/node_modules/open": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
+      "integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
+      "dev": true,
+      "dependencies": {
+        "is-docker": "^2.0.0",
+        "is-wsl": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/tailwindcss": {
+      "version": "3.4.19",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
+      "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
+      "dev": true,
+      "dependencies": {
+        "@alloc/quick-lru": "^5.2.0",
+        "arg": "^5.0.2",
+        "chokidar": "^3.6.0",
+        "didyoumean": "^1.2.2",
+        "dlv": "^1.1.3",
+        "fast-glob": "^3.3.2",
+        "glob-parent": "^6.0.2",
+        "is-glob": "^4.0.3",
+        "jiti": "^1.21.7",
+        "lilconfig": "^3.1.3",
+        "micromatch": "^4.0.8",
+        "normalize-path": "^3.0.0",
+        "object-hash": "^3.0.0",
+        "picocolors": "^1.1.1",
+        "postcss": "^8.4.47",
+        "postcss-import": "^15.1.0",
+        "postcss-js": "^4.0.1",
+        "postcss-load-config": "^4.0.2 || ^5.0 || ^6.0",
+        "postcss-nested": "^6.2.0",
+        "postcss-selector-parser": "^6.1.2",
+        "resolve": "^1.22.8",
+        "sucrase": "^3.35.0"
+      },
+      "bin": {
+        "tailwind": "lib/cli.js",
+        "tailwindcss": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tailwindcss/node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/tailwindcss/node_modules/chokidar/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/tailwindcss/node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/tailwindcss/node_modules/jiti": {
+      "version": "1.21.7",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
+      "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
+      "dev": true,
+      "bin": {
+        "jiti": "bin/jiti.js"
+      }
+    },
+    "node_modules/tailwindcss/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tailwindcss/node_modules/postcss-selector-parser": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.4.tgz",
+      "integrity": "sha512-bIoJLOmjCO1S9XdY/DcnR5hJxvrDir1PbGChrzXG3vw0/FOliy/fA3dmdhQ441kah4gKv+TwckGzex6wNS5cnQ==",
+      "dev": true,
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/tailwindcss/node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
+    "node_modules/tailwindcss/node_modules/resolve": {
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "dev": true,
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/tapable": {
@@ -9119,6 +10153,27 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
       "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg=="
+    },
+    "node_modules/thenify": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+      "dev": true,
+      "dependencies": {
+        "any-promise": "^1.0.0"
+      }
+    },
+    "node_modules/thenify-all": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+      "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+      "dev": true,
+      "dependencies": {
+        "thenify": ">= 3.1.0 < 4"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
     },
     "node_modules/tiny-invariant": {
       "version": "1.3.3",
@@ -9217,15 +10272,32 @@
         "typescript": ">=4.8.4"
       }
     },
+    "node_modules/ts-interface-checker": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
+      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
+      "dev": true
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
+    "node_modules/tsscmp": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/tsscmp/-/tsscmp-1.0.6.tgz",
+      "integrity": "sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.6.x"
+      }
+    },
     "node_modules/tsx": {
       "version": "4.20.3",
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.20.3.tgz",
       "integrity": "sha512-qjbnuR9Tr+FJOMBqJCW5ehvIo/buZq7vH7qD7JziU98h6l3qGy0a/yPFjwO+y0/T7GFpNgNAvEcPPVfyT8rrPQ==",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.25.0",
         "get-tsconfig": "^4.7.5"
@@ -9251,6 +10323,40 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "dev": true,
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/type-is/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/type-is/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
@@ -9272,19 +10378,6 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/ultrahtml/-/ultrahtml-1.6.0.tgz",
       "integrity": "sha512-R9fBn90VTJrqqLDwyMph+HGne8eqY1iPfYhPzZrvKpIfwkWZbcYlfpsb8B9dTvBfpy1/hqAD7Wi8EKfP9e8zdw=="
-    },
-    "node_modules/unconfig": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/unconfig/-/unconfig-0.5.5.tgz",
-      "integrity": "sha512-VQZ5PT9HDX+qag0XdgQi8tJepPhXiR/yVOkn707gJDKo31lGjRilPREiQJ9Z6zd/Ugpv6ZvO5VxVIcatldYcNQ==",
-      "dependencies": {
-        "@antfu/utils": "^0.7.10",
-        "defu": "^6.1.4",
-        "importx": "^0.4.3"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/antfu"
-      }
     },
     "node_modules/uncrypto": {
       "version": "0.1.3",
@@ -9364,6 +10457,15 @@
       },
       "engines": {
         "node": ">=18.12.0"
+      }
+    },
+    "node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 10.0.0"
       }
     },
     "node_modules/unixify": {
@@ -9625,15 +10727,6 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/upath": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/upath/-/upath-2.0.1.tgz",
-      "integrity": "sha512-1uEe95xksV1O0CYKXo8vQvN1JEbtJp7lb7C5U9HMsIp6IVwntkH/oNUzyVNQSd4S1sYk2FpSSW44FqMc8qee5w==",
-      "engines": {
-        "node": ">=4",
-        "yarn": "*"
-      }
-    },
     "node_modules/update-browserslist-db": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
@@ -9697,6 +10790,15 @@
       "dependencies": {
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/vite": {
@@ -9993,24 +11095,6 @@
         "vue": "^3.5.0"
       }
     },
-    "node_modules/vite-plugin-vuetify": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/vite-plugin-vuetify/-/vite-plugin-vuetify-2.1.1.tgz",
-      "integrity": "sha512-Pb7bKhQH8qPMzURmEGq2aIqCJkruFNsyf1NcrrtnjsOIkqJPMcBbiP0oJoO8/uAmyB5W/1JTbbUEsyXdMM0QHQ==",
-      "dependencies": {
-        "@vuetify/loader-shared": "^2.1.0",
-        "debug": "^4.3.3",
-        "upath": "^2.0.1"
-      },
-      "engines": {
-        "node": "^18.0.0 || >=20.0.0"
-      },
-      "peerDependencies": {
-        "vite": ">=5",
-        "vue": "^3.0.0",
-        "vuetify": "^3.0.0"
-      }
-    },
     "node_modules/vscode-uri": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
@@ -10062,93 +11146,6 @@
       "peerDependencies": {
         "vue": "^3.2.0"
       }
-    },
-    "node_modules/vuetify": {
-      "version": "3.8.9",
-      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-3.8.9.tgz",
-      "integrity": "sha512-X9kCxeqf7w5sca2Mfn4NCVsDDimi81jxKyqsZHjW0XG/rTdtwRFKttxOcv0Mmi+67ulPjDZywA7pBFK0rxoafA==",
-      "engines": {
-        "node": "^12.20 || >=14.13"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/johnleider"
-      },
-      "peerDependencies": {
-        "typescript": ">=4.7",
-        "vite-plugin-vuetify": ">=2.1.0",
-        "vue": "^3.5.0",
-        "webpack-plugin-vuetify": ">=3.1.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        },
-        "vite-plugin-vuetify": {
-          "optional": true
-        },
-        "webpack-plugin-vuetify": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/vuetify-nuxt-module": {
-      "version": "0.18.7",
-      "resolved": "https://registry.npmjs.org/vuetify-nuxt-module/-/vuetify-nuxt-module-0.18.7.tgz",
-      "integrity": "sha512-AEP5DRuyY5yIk8JzPEhG6NohCkGwf9afn4Mv51YPKGxreqP/KfzL0jooG/HN1cinSo4c+9uRowHllzCsnSN7FA==",
-      "dependencies": {
-        "@nuxt/kit": "^3.12.4",
-        "defu": "^6.1.4",
-        "destr": "^2.0.3",
-        "local-pkg": "^0.5.0",
-        "pathe": "^1.1.2",
-        "perfect-debounce": "^1.0.0",
-        "ufo": "^1.5.4",
-        "unconfig": "^0.5.5",
-        "upath": "^2.0.1",
-        "vite-plugin-vuetify": "^2.1.0",
-        "vuetify": "^3.7.0"
-      }
-    },
-    "node_modules/vuetify-nuxt-module/node_modules/confbox": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
-      "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w=="
-    },
-    "node_modules/vuetify-nuxt-module/node_modules/local-pkg": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-0.5.1.tgz",
-      "integrity": "sha512-9rrA30MRRP3gBD3HTGnC6cDFpaE1kVDWxWgqWJUN0RvDNAo+Nz/9GxB+nHOH0ifbVFy0hSA1V6vFDvnx54lTEQ==",
-      "dependencies": {
-        "mlly": "^1.7.3",
-        "pkg-types": "^1.2.1"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/antfu"
-      }
-    },
-    "node_modules/vuetify-nuxt-module/node_modules/pathe": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
-      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ=="
-    },
-    "node_modules/vuetify-nuxt-module/node_modules/pkg-types": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
-      "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
-      "dependencies": {
-        "confbox": "^0.1.8",
-        "mlly": "^1.7.4",
-        "pathe": "^2.0.1"
-      }
-    },
-    "node_modules/vuetify-nuxt-module/node_modules/pkg-types/node_modules/pathe": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
-      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="
     },
     "node_modules/web-streams-polyfill": {
       "version": "3.3.3",
@@ -10495,6 +11492,15 @@
       "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/ylru": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/ylru/-/ylru-1.4.0.tgz",
+      "integrity": "sha512-2OQsPNEmBCvXuFlIni/a+Rn+R2pHW9INm0BxXJ4hVDA8TirqMj+J/Rp9ItLatT/5pZqWwefVrTQcHpixsxnVlA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 4.0.0"
       }
     },
     "node_modules/yocto-queue": {

--- a/gui/package.json
+++ b/gui/package.json
@@ -7,7 +7,8 @@
     "dev": "nuxt dev",
     "generate": "nuxt generate",
     "preview": "nuxt preview",
-    "postinstall": "nuxt prepare"
+    "postinstall": "nuxt prepare",
+    "test": "vitest run"
   },
   "dependencies": {
     "@nuxt/icon": "^1.10.3",
@@ -19,6 +20,7 @@
   "devDependencies": {
     "@iconify-json/lucide": "^1.2.30",
     "@nuxtjs/tailwindcss": "^6.13.1",
-    "tailwindcss": "^3.4.17"
+    "tailwindcss": "^3.4.17",
+    "vitest": "^2.1.9"
   }
 }

--- a/gui/package.json
+++ b/gui/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "nuxt-app",
+  "name": "ticktask-gui",
   "private": true,
   "type": "module",
   "scripts": {
@@ -10,9 +10,15 @@
     "postinstall": "nuxt prepare"
   },
   "dependencies": {
+    "@nuxt/icon": "^1.10.3",
+    "jwt-decode": "^4.0.0",
     "nuxt": "^3.17.5",
     "vue": "^3.5.16",
-    "vue-router": "^4.5.1",
-    "vuetify-nuxt-module": "^0.18.7"
+    "vue-router": "^4.5.1"
+  },
+  "devDependencies": {
+    "@iconify-json/lucide": "^1.2.30",
+    "@nuxtjs/tailwindcss": "^6.13.1",
+    "tailwindcss": "^3.4.17"
   }
 }

--- a/gui/pages/calendar.vue
+++ b/gui/pages/calendar.vue
@@ -1,9 +1,9 @@
 <template>
   <div class="mx-auto max-w-6xl space-y-6">
     <div>
-      <h1 class="text-2xl font-bold tracking-tight sm:text-3xl">History</h1>
+      <h1 class="text-2xl font-bold tracking-tight sm:text-3xl">Calendar</h1>
       <p class="mt-1 text-muted-foreground">
-        Browse and review your past time entries.
+        Review tracked time and plan future events.
       </p>
     </div>
 
@@ -11,13 +11,13 @@
       <div class="flex flex-col items-center gap-3 py-16 text-center">
         <div
           class="flex size-14 items-center justify-center rounded-2xl bg-muted text-muted-foreground">
-          <Icon name="lucide:history" class="size-7" />
+          <Icon name="lucide:calendar-days" class="size-7" />
         </div>
         <div>
           <p class="font-semibold">Coming soon</p>
           <p class="mt-1 max-w-sm text-sm text-muted-foreground">
-            A searchable history of every time entry, grouped by task and date,
-            is on the way.
+            A month/week calendar showing your tracked time plus the events you
+            schedule.
           </p>
         </div>
       </div>

--- a/gui/pages/dashboard.vue
+++ b/gui/pages/dashboard.vue
@@ -1,9 +1,9 @@
 <template>
   <div class="mx-auto max-w-6xl space-y-6">
     <div>
-      <h1 class="text-2xl font-bold tracking-tight sm:text-3xl">History</h1>
+      <h1 class="text-2xl font-bold tracking-tight sm:text-3xl">Dashboard</h1>
       <p class="mt-1 text-muted-foreground">
-        Browse and review your past time entries.
+        Hours spent across your tasks and subtasks.
       </p>
     </div>
 
@@ -11,13 +11,13 @@
       <div class="flex flex-col items-center gap-3 py-16 text-center">
         <div
           class="flex size-14 items-center justify-center rounded-2xl bg-muted text-muted-foreground">
-          <Icon name="lucide:history" class="size-7" />
+          <Icon name="lucide:chart-column" class="size-7" />
         </div>
         <div>
           <p class="font-semibold">Coming soon</p>
           <p class="mt-1 max-w-sm text-sm text-muted-foreground">
-            A searchable history of every time entry, grouped by task and date,
-            is on the way.
+            Charts of time per task, trends over time, and summary stats will
+            live here.
           </p>
         </div>
       </div>

--- a/gui/pages/home.vue
+++ b/gui/pages/home.vue
@@ -1,7 +1,5 @@
 <template>
-  <v-container fluid class="fill-height">
-    <Home />
-  </v-container>
+  <Home />
 </template>
 
 <script setup>

--- a/gui/pages/index.vue
+++ b/gui/pages/index.vue
@@ -1,9 +1,79 @@
 <template>
-  <v-container
-    class="d-flex flex-column justify-center align-center"
-    style="height: 85vh">
-    <div class="text-h3 mb-10">Welcome to TickTask</div>
-  </v-container>
+  <section class="relative overflow-hidden">
+    <!-- Decorative gradient -->
+    <div
+      class="pointer-events-none absolute inset-x-0 -top-40 -z-10 flex justify-center blur-3xl"
+      aria-hidden="true">
+      <div
+        class="h-72 w-[36rem] bg-gradient-to-tr from-primary/30 to-accent/20 opacity-60"></div>
+    </div>
+
+    <div
+      class="mx-auto flex max-w-3xl flex-col items-center px-6 py-24 text-center sm:py-32">
+      <span
+        class="mb-6 inline-flex items-center gap-2 rounded-full border border-border bg-card px-3.5 py-1.5 text-sm text-muted-foreground">
+        <span class="size-2 rounded-full bg-accent"></span>
+        Track time. Plan ahead. Stay on top.
+      </span>
+
+      <h1 class="text-4xl font-extrabold tracking-tight sm:text-6xl">
+        Your tasks and time,
+        <span
+          class="bg-gradient-to-r from-primary to-accent bg-clip-text text-transparent">
+          in one place
+        </span>
+      </h1>
+
+      <p class="mt-6 max-w-xl text-lg text-muted-foreground">
+        Organize work into tasks and subtasks, clock in and out as you go, and
+        see exactly where your hours went — with a dashboard and calendar to
+        plan what's next.
+      </p>
+
+      <div class="mt-10 flex flex-wrap items-center justify-center gap-3">
+        <UiButton
+          :to="auth.isAuthenticated.value ? '/home' : '/login'"
+          size="lg"
+          icon="lucide:arrow-right">
+          {{ auth.isAuthenticated.value ? "Open the app" : "Get started" }}
+        </UiButton>
+      </div>
+
+      <div class="mt-16 grid w-full gap-4 sm:grid-cols-3">
+        <div
+          v-for="f in features"
+          :key="f.title"
+          class="card-surface p-5 text-left">
+          <div
+            class="flex size-10 items-center justify-center rounded-xl bg-primary/10 text-primary">
+            <Icon :name="f.icon" class="size-5" />
+          </div>
+          <h3 class="mt-4 font-semibold">{{ f.title }}</h3>
+          <p class="mt-1 text-sm text-muted-foreground">{{ f.text }}</p>
+        </div>
+      </div>
+    </div>
+  </section>
 </template>
 
-<script setup></script>
+<script setup>
+  const auth = useAuth();
+
+  const features = [
+    {
+      icon: "lucide:list-checks",
+      title: "Tasks & subtasks",
+      text: "Break work down and keep everything structured.",
+    },
+    {
+      icon: "lucide:timer",
+      title: "Time tracking",
+      text: "One-tap clock in / out on whatever you're doing.",
+    },
+    {
+      icon: "lucide:calendar-days",
+      title: "Plan ahead",
+      text: "A calendar and dashboard to review and schedule.",
+    },
+  ];
+</script>

--- a/gui/pages/login.vue
+++ b/gui/pages/login.vue
@@ -1,45 +1,75 @@
 <template>
-  <v-container class="fill-height d-flex justify-center align-center">
-    <v-card class="pa-6" width="400" elevation="16">
-      <v-card-title class="text-center">LogIn</v-card-title>
+  <div class="flex min-h-screen items-center justify-center p-4">
+    <!-- Decorative gradient -->
+    <div
+      class="pointer-events-none absolute inset-x-0 top-0 -z-10 flex justify-center blur-3xl"
+      aria-hidden="true">
+      <div
+        class="h-64 w-[32rem] bg-gradient-to-tr from-primary/25 to-accent/15 opacity-70"></div>
+    </div>
 
-      <v-card-text>
-        <v-form @submit.prevent="login">
-          <v-text-field
+    <div class="absolute right-4 top-4">
+      <UiThemeToggle />
+    </div>
+
+    <div class="w-full max-w-sm">
+      <div class="mb-8 flex flex-col items-center text-center">
+        <div
+          class="flex size-12 items-center justify-center rounded-2xl bg-primary text-primary-foreground shadow-soft">
+          <Icon name="lucide:timer" class="size-6" />
+        </div>
+        <h1 class="mt-4 text-2xl font-bold tracking-tight">Welcome back</h1>
+        <p class="mt-1 text-sm text-muted-foreground">
+          Log in to your TickTask account
+        </p>
+      </div>
+
+      <div class="card-surface p-6 shadow-card">
+        <form class="space-y-4" @submit.prevent="login">
+          <UiInput
             v-model="username"
-            label="User"
-            variant="underlined"
-            prepend-inner-icon="mdi-account"
-            autofocus></v-text-field>
+            label="Username"
+            placeholder="your username"
+            icon="lucide:user"
+            autocomplete="username"
+            autofocus />
 
-          <v-text-field
+          <UiInput
             v-model="password"
             label="Password"
-            :type="showPassword ? 'text' : 'password'"
-            variant="underlined"
-            prepend-inner-icon="mdi-key-variant"
-            :append-inner-icon="showPassword ? 'mdi-eye' : 'mdi-eye-off'"
-            @click:append-inner="showPassword = !showPassword"></v-text-field>
+            type="password"
+            placeholder="••••••••"
+            icon="lucide:lock"
+            autocomplete="current-password"
+            revealable
+            @enter="login" />
 
-          <v-btn color="primary" block type="submit" :loading="loading">
-            Access
-          </v-btn>
+          <UiAlert v-if="errorMessage" variant="danger">{{
+            errorMessage
+          }}</UiAlert>
 
-          <v-btn color="primary" block variant="text" class="mt-4" to="/">
-            Return
-          </v-btn>
-        </v-form>
+          <UiButton type="submit" block size="lg" :loading="loading"
+            >Log in</UiButton
+          >
+        </form>
+      </div>
 
-        <v-alert v-if="errorMessage" type="error" class="mt-3" dense>
-          {{ errorMessage }}
-        </v-alert>
-      </v-card-text>
-    </v-card>
-  </v-container>
+      <div class="mt-6 text-center">
+        <NuxtLink
+          to="/"
+          class="text-sm text-muted-foreground transition-colors hover:text-foreground">
+          ← Back to home
+        </NuxtLink>
+      </div>
+    </div>
+  </div>
 </template>
 
 <script setup>
+  import { ref } from "vue";
   import { useRouter } from "vue-router";
+
+  definePageMeta({ layout: "blank" });
 
   const auth = useAuth();
   const router = useRouter();
@@ -47,28 +77,25 @@
   const username = ref("");
   const password = ref("");
   const errorMessage = ref("");
-
-  const showPassword = ref(false);
-
   const loading = ref(false);
 
   const login = async () => {
+    if (loading.value) return;
     errorMessage.value = "";
-    loading.value = true;
 
     if (!username.value || !password.value) {
-      errorMessage.value = "You must introduce user and password";
-    } else {
-      try {
-        const success = await auth.login(username.value, password.value);
-        if (success) {
-          router.push("/home");
-        }
-      } catch (error) {
-        errorMessage.value = error.message || "Incorrect user or password";
-      }
+      errorMessage.value = "Please enter your username and password.";
+      return;
     }
 
-    loading.value = false;
+    loading.value = true;
+    try {
+      const success = await auth.login(username.value, password.value);
+      if (success) router.push("/home");
+    } catch (error) {
+      errorMessage.value = error.message || "Incorrect username or password.";
+    } finally {
+      loading.value = false;
+    }
   };
 </script>

--- a/gui/pages/time-tracking.vue
+++ b/gui/pages/time-tracking.vue
@@ -1,164 +1,219 @@
 <template>
-  <v-container>
-    <v-card class="pa-4" elevation="2">
-      <v-card-title>Select a Task</v-card-title>
+  <div class="mx-auto max-w-6xl space-y-6">
+    <div>
+      <h1 class="text-2xl font-bold tracking-tight sm:text-3xl">
+        Time tracking
+      </h1>
+      <p class="mt-1 text-muted-foreground">
+        Pick a subtask and clock in to start tracking.
+      </p>
+    </div>
 
-      <v-data-table
-        :headers="taskHeaders"
-        :items="tasks"
-        item-value="id"
-        :items-per-page="5"
-        :hide-default-footer="true"
-        :loading="loadingTasks"
-        class="mb-6 rounded-lg elevation-1"
-        dense
-        hover
-        show-expand
-        expand-on-click
-        v-model:expanded="expanded">
-        <template #item.name="{ item }">
-          <span
-            @click="selectTask(item)"
-            :class="{
-              'text-blue-darken-3 font-weight-bold':
-                selectedTask?.id === item.id && selectSubtask,
-            }">
-            {{ item.name }}
-          </span>
-        </template>
+    <div class="grid gap-6 lg:grid-cols-5">
+      <!-- Task / subtask picker -->
+      <div class="lg:col-span-3">
+        <UiCard title="Your tasks">
+          <template #actions>
+            <UiButton size="sm" icon="lucide:plus" @click="openAddTaskDialog"
+              >Add task</UiButton
+            >
+          </template>
 
-        <template #expanded-row="{ item }">
-          <tr>
-            <td :colspan="taskHeaders.length">
-              <v-data-table
-                :headers="subtaskHeaders"
-                :items="item.subtasks"
-                item-value="id"
-                dense
-                hide-default-footer
-                class="rounded-lg elevation-0">
-                <template #item.name="{ item: subtask }">
-                  <span
-                    @click.stop="selectSubtask(subtask, item)"
-                    :class="{
-                      'text-green-darken-3 font-weight-bold':
-                        selectedSubtask?.id === subtask.id &&
-                        selectedTask?.id === item.id,
-                    }"
-                    style="cursor: pointer">
-                    {{ subtask.name }}
-                  </span>
-                </template>
+          <div
+            v-if="loadingTasks"
+            class="flex items-center justify-center py-12 text-muted-foreground">
+            <Icon name="lucide:loader-circle" class="size-6 animate-spin" />
+          </div>
 
-                <template #body.append>
-                  <tr>
-                    <td :colspan="subtaskHeaders.length">
-                      <v-btn
-                        color="primary"
-                        @click="openAddSubTaskDialog(item)"
-                        block>
-                        ➕ Add Subtask
-                      </v-btn>
-                    </td>
-                  </tr>
-                </template>
-              </v-data-table>
-            </td>
-          </tr>
-        </template>
-
-        <template #body.append>
-          <tr>
-            <td :colspan="taskHeaders.length">
-              <v-btn
-                color="primary"
-                @click="openAddTaskDialog"
-                variant="flat"
-                block>
-                ➕ Add Task
-              </v-btn>
-            </td>
-          </tr>
-        </template>
-      </v-data-table>
-
-      <v-row v-if="isClockedIn && clockInTime" class="mt-2" justify="center">
-        <v-col cols="12" class="text-center">
-          <v-alert type="success" variant="tonal">
+          <div
+            v-else-if="!tasks.length"
+            class="flex flex-col items-center gap-3 py-12 text-center">
+            <div
+              class="flex size-12 items-center justify-center rounded-2xl bg-muted text-muted-foreground">
+              <Icon name="lucide:folder-plus" class="size-6" />
+            </div>
             <div>
-              📝 <strong>Task:</strong> {{ activeTask?.name || "N/A" }}<br />
-              🧩 <strong>Subtask:</strong> {{ activeSubTask?.name || "N/A"
-              }}<br />
-              ⏰ <strong>Clocked in at:</strong>
-              {{ clockInTime.toLocaleTimeString() }}<br />
-              ⏳ <strong>Time elapsed:</strong> {{ clockInDuration }}
+              <p class="font-medium">No tasks yet</p>
+              <p class="text-sm text-muted-foreground">
+                Create your first task to start tracking time.
+              </p>
+            </div>
+            <UiButton size="sm" icon="lucide:plus" @click="openAddTaskDialog"
+              >Add task</UiButton
+            >
+          </div>
+
+          <ul v-else class="space-y-2">
+            <li
+              v-for="task in tasks"
+              :key="task.id"
+              class="overflow-hidden rounded-xl border border-border">
+              <button
+                class="flex w-full items-center gap-3 px-4 py-3 text-left transition-colors hover:bg-muted"
+                @click="toggleExpand(task.id)">
+                <Icon
+                  name="lucide:chevron-right"
+                  class="size-4 text-muted-foreground transition-transform"
+                  :class="{ 'rotate-90': isExpanded(task.id) }" />
+                <Icon name="lucide:folder" class="size-[18px] text-primary" />
+                <span class="flex-1 font-medium">{{ task.name }}</span>
+                <span
+                  class="rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground">
+                  {{ task.subtasks.length }} subtask{{
+                    task.subtasks.length === 1 ? "" : "s"
+                  }}
+                </span>
+              </button>
+
+              <div
+                v-if="isExpanded(task.id)"
+                class="border-t border-border bg-background/40 px-3 py-2">
+                <button
+                  v-for="subtask in task.subtasks"
+                  :key="subtask.id"
+                  class="flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-left text-sm transition-colors"
+                  :class="
+                    isSelected(task, subtask)
+                      ? 'bg-primary/10 text-primary'
+                      : 'hover:bg-muted'
+                  "
+                  @click="selectSubtask(subtask, task)">
+                  <Icon
+                    :name="
+                      isSelected(task, subtask)
+                        ? 'lucide:circle-check-big'
+                        : 'lucide:circle'
+                    "
+                    class="size-[18px] shrink-0" />
+                  <span class="flex-1">
+                    <span class="font-medium">{{ subtask.name }}</span>
+                    <span
+                      v-if="subtask.description"
+                      class="ml-2 text-muted-foreground"
+                      >{{ subtask.description }}</span
+                    >
+                  </span>
+                </button>
+
+                <p
+                  v-if="!task.subtasks.length"
+                  class="px-3 py-2 text-sm text-muted-foreground">
+                  No subtasks yet.
+                </p>
+
+                <UiButton
+                  variant="ghost"
+                  size="sm"
+                  icon="lucide:plus"
+                  class="mt-1 w-full justify-start"
+                  @click="openAddSubTaskDialog(task)">
+                  Add subtask
+                </UiButton>
+              </div>
+            </li>
+          </ul>
+        </UiCard>
+      </div>
+
+      <!-- Tracker -->
+      <div class="lg:col-span-2">
+        <UiCard title="Tracker" class="lg:sticky lg:top-6">
+          <!-- Active session -->
+          <div v-if="isClockedIn && clockInTime" class="space-y-5">
+            <div class="rounded-2xl bg-accent/10 p-5 text-center">
+              <p class="text-sm text-muted-foreground">Tracking</p>
+              <p class="mt-1 font-semibold">{{ activeTask?.name }}</p>
+              <p class="text-sm text-muted-foreground">
+                {{ activeSubTask?.name }}
+              </p>
+              <p
+                class="mt-4 font-mono text-4xl font-bold tabular-nums tracking-tight">
+                {{ clockInDuration }}
+              </p>
+              <p class="mt-1 text-xs text-muted-foreground">
+                Started at {{ clockInTime.toLocaleTimeString() }}
+              </p>
             </div>
 
-            <div v-if="recentTimeEntries.length" class="mt-3">
-              <strong>⏱ Latest time entries (24h):</strong>
-              <ul class="mt-1">
-                <li v-for="entry in recentTimeEntries" :key="entry.id">
-                  {{ new Date(entry.clock_in).toLocaleTimeString() }}
-                  -
-                  {{
-                    entry.clock_out
-                      ? new Date(entry.clock_out).toLocaleTimeString()
-                      : "Ongoing"
-                  }}
+            <UiButton
+              variant="danger"
+              block
+              size="lg"
+              icon="lucide:square"
+              @click="clockOut">
+              Clock out
+            </UiButton>
+
+            <div v-if="recentTimeEntries.length">
+              <p class="mb-2 text-sm font-medium text-muted-foreground">
+                Recent entries (24h)
+              </p>
+              <ul class="space-y-1.5">
+                <li
+                  v-for="entry in recentTimeEntries"
+                  :key="entry.id"
+                  class="flex items-center justify-between rounded-lg bg-muted px-3 py-2 text-sm">
+                  <span
+                    >{{ formatTime(entry.clock_in) }} –
+                    {{
+                      entry.clock_out ? formatTime(entry.clock_out) : "ongoing"
+                    }}</span
+                  >
+                  <Icon
+                    :name="
+                      entry.clock_out ? 'lucide:check' : 'lucide:loader-circle'
+                    "
+                    class="size-4 text-muted-foreground"
+                    :class="{ 'animate-spin': !entry.clock_out }" />
                 </li>
               </ul>
             </div>
-            <div v-else class="mt-3">
-              <em>No time entries in the last 24 hours.</em>
-            </div>
-          </v-alert>
-        </v-col>
-      </v-row>
-      <v-row
-        v-if="selectedTask && selectedSubtask"
-        class="mt-6"
-        justify="center">
-        <v-btn
-          color="success"
-          class="ma-2"
-          :disabled="!canClockIn"
-          @click="clockIn">
-          ✅ Clock In
-        </v-btn>
-        <v-btn
-          color="error"
-          class="ma-2"
-          :disabled="!canClockOut"
-          @click="clockOut">
-          ❌ Clock Out
-        </v-btn>
-      </v-row>
-    </v-card>
-    <v-row v-if="selectedTask && selectedSubtask" class="mt-6" justify="center">
-      <v-col cols="12" class="text-center">
-        <v-alert type="info" variant="tonal">
-          <strong>Selected Task:</strong> {{ selectedTask.name }}<br />
-          <strong>Selected Subtask:</strong> {{ selectedSubtask.name }}
-        </v-alert>
-      </v-col>
-    </v-row>
-  </v-container>
-  <AddTaskDialog
-    v-model="dialogAddTaskVisible"
-    @task-created="handleTaskCreated" />
+          </div>
 
-  <AddSubTaskDialog
-    v-if="currentTaskForSubtask"
-    v-model="dialogAddSubTaskVisible"
-    :task-id="currentTaskForSubtask.id"
-    @subtask-created="handleSubTaskCreated" />
+          <!-- Idle -->
+          <div v-else class="space-y-5">
+            <div
+              v-if="selectedSubtask"
+              class="rounded-2xl bg-muted p-5 text-center">
+              <p class="text-sm text-muted-foreground">Selected</p>
+              <p class="mt-1 font-semibold">{{ selectedTask?.name }}</p>
+              <p class="text-sm text-muted-foreground">
+                {{ selectedSubtask.name }}
+              </p>
+            </div>
+            <div
+              v-else
+              class="flex flex-col items-center gap-2 rounded-2xl border border-dashed border-border p-8 text-center text-muted-foreground">
+              <Icon name="lucide:mouse-pointer-click" class="size-7" />
+              <p class="text-sm">Select a subtask to begin.</p>
+            </div>
+
+            <UiButton
+              block
+              size="lg"
+              icon="lucide:play"
+              :disabled="!canClockIn"
+              @click="clockIn">
+              Clock in
+            </UiButton>
+          </div>
+        </UiCard>
+      </div>
+    </div>
+
+    <AddTaskDialog
+      v-model="dialogAddTaskVisible"
+      @task-created="handleTaskCreated" />
+    <AddSubTaskDialog
+      v-if="currentTaskForSubtask"
+      v-model="dialogAddSubTaskVisible"
+      :task-id="currentTaskForSubtask.id"
+      @subtask-created="handleSubTaskCreated" />
+  </div>
 </template>
 
 <script setup>
-  // TODO(David): Allow to delete tasks and subtasks
   import { ref, computed, onMounted, onBeforeUnmount } from "vue";
-  import AddTaskDialog from "~/components/AddTaskDialog.vue";
-  import AddSubTaskDialog from "~/components/AddSubTaskDialog.vue";
 
   definePageMeta({
     middleware: "auth",
@@ -169,18 +224,14 @@
   const { $api } = useNuxtApp();
 
   const tasks = ref([]);
-  const taskHeaders = [{ text: "Task", value: "name" }];
-  const subtaskHeaders = [{ text: "Subtask", value: "name" }];
+  const loadingTasks = ref(false);
+  const expanded = ref([]);
 
   const selectedTask = ref(null);
   const selectedSubtask = ref(null);
   const activeTask = ref(null);
   const activeSubTask = ref(null);
   const isClockedIn = ref(false);
-  const loadingTasks = ref(false);
-  const dialogAddTaskVisible = ref(false);
-  const dialogAddSubTaskVisible = ref(false);
-  const currentTaskForSubtask = ref(null);
 
   const clockInTime = ref(null);
   const clockInDuration = ref("00:00:00");
@@ -188,35 +239,34 @@
   const activeTimeEntryId = ref(null);
   const recentTimeEntries = ref([]);
 
-  const expanded = ref([]);
+  const dialogAddTaskVisible = ref(false);
+  const dialogAddSubTaskVisible = ref(false);
+  const currentTaskForSubtask = ref(null);
 
   onMounted(async () => {
     loadingTasks.value = true;
     try {
-      const response = await $api("/ticktask/user/get-tasks-and-subtasks/", {
+      tasks.value = await $api("/ticktask/user/get-tasks-and-subtasks/", {
         method: "GET",
       });
-      tasks.value = response;
 
-      const timeEntryResponse = await $api(
-        "/ticktask/user/get-clocked-in-time-entry/",
-        { method: "GET" }
-      );
-
-      if (timeEntryResponse) {
-        const task = timeEntryResponse;
-        const subtask = task.subtasks[0];
+      const active = await $api("/ticktask/user/get-clocked-in-time-entry/", {
+        method: "GET",
+      });
+      if (active) {
+        const subtask = active.subtasks[0];
         const entry = subtask.time_entries[0];
 
-        selectedTask.value = task;
-        activeTask.value = task;
+        selectedTask.value = active;
+        activeTask.value = active;
         selectedSubtask.value = subtask;
         activeSubTask.value = subtask;
         activeTimeEntryId.value = entry.id;
         isClockedIn.value = true;
         clockInTime.value = new Date(entry.clock_in);
+        expanded.value = [active.id];
         startClockInTimer();
-        fetchRecentTimeEntries(activeSubTask.value.id);
+        fetchRecentTimeEntries(subtask.id);
       }
     } catch (error) {
       console.error("Error fetching tasks:", error);
@@ -226,15 +276,24 @@
   });
 
   const canClockIn = computed(
-    () => selectedTask.value && selectedSubtask.value && !isClockedIn.value
-  );
-  const canClockOut = computed(
-    () => selectedTask.value && selectedSubtask.value && isClockedIn.value
+    () => !!selectedTask.value && !!selectedSubtask.value && !isClockedIn.value,
   );
 
-  function selectTask(task) {
-    selectedTask.value = task;
-    selectedSubtask.value = null;
+  function isExpanded(taskId) {
+    return expanded.value.includes(taskId);
+  }
+
+  function toggleExpand(taskId) {
+    expanded.value = isExpanded(taskId)
+      ? expanded.value.filter((id) => id !== taskId)
+      : [...expanded.value, taskId];
+  }
+
+  function isSelected(task, subtask) {
+    return (
+      selectedTask.value?.id === task.id &&
+      selectedSubtask.value?.id === subtask.id
+    );
   }
 
   function selectSubtask(subtask, task) {
@@ -247,18 +306,16 @@
       const existing = await $api("/ticktask/user/get-clocked-in-time-entry/", {
         method: "GET",
       });
-
       if (existing) {
         alert(
-          "You have an already active Task. Please, close it before starting a new one."
+          "You already have an active task. Please close it before starting a new one.",
         );
         return;
       }
+
       const response = await $api("/ticktask/user/clock-in/", {
         method: "POST",
-        body: {
-          subtask_id: selectedSubtask.value.id,
-        },
+        body: { subtask_id: selectedSubtask.value.id },
       });
 
       isClockedIn.value = true;
@@ -275,12 +332,9 @@
 
   async function clockOut() {
     try {
-      console.log("entry id: ", activeTimeEntryId.value);
-      const response = await $api("/ticktask/user/clock-out/", {
+      await $api("/ticktask/user/clock-out/", {
         method: "POST",
-        body: {
-          entity_id: activeTimeEntryId.value,
-        },
+        body: { entity_id: activeTimeEntryId.value },
       });
 
       isClockedIn.value = false;
@@ -291,6 +345,7 @@
       activeTimeEntryId.value = null;
       activeTask.value = null;
       activeSubTask.value = null;
+      recentTimeEntries.value = [];
     } catch (err) {
       console.error("Error during clock out:", err);
     }
@@ -298,12 +353,10 @@
 
   async function fetchRecentTimeEntries(subtaskId) {
     try {
-      const response = await $api("/ticktask/user/get-time-entries/", {
+      recentTimeEntries.value = await $api("/ticktask/user/get-time-entries/", {
         method: "POST",
         body: { subtask_id: subtaskId, last_hours: 24 },
       });
-
-      recentTimeEntries.value = response;
     } catch (err) {
       console.error("Error fetching recent time entries:", err);
       recentTimeEntries.value = [];
@@ -312,32 +365,36 @@
 
   function startClockInTimer() {
     if (clockInterval) clearInterval(clockInterval);
-
     clockInterval = setInterval(() => {
-      const now = new Date();
-      const diff = now - clockInTime.value; // en ms
-
+      const diff = new Date() - clockInTime.value;
       const hours = String(Math.floor(diff / 3600000)).padStart(2, "0");
       const minutes = String(Math.floor((diff % 3600000) / 60000)).padStart(
         2,
-        "0"
+        "0",
       );
       const seconds = String(Math.floor((diff % 60000) / 1000)).padStart(
         2,
-        "0"
+        "0",
       );
-
       clockInDuration.value = `${hours}:${minutes}:${seconds}`;
     }, 1000);
   }
 
-  const openAddTaskDialog = () => {
-    dialogAddTaskVisible.value = true;
-  };
+  function formatTime(value) {
+    return new Date(value).toLocaleTimeString([], {
+      hour: "2-digit",
+      minute: "2-digit",
+    });
+  }
 
-  const handleTaskCreated = (task) => {
-    tasks.value.push(task);
-  };
+  function openAddTaskDialog() {
+    dialogAddTaskVisible.value = true;
+  }
+
+  function handleTaskCreated(task) {
+    tasks.value.push({ ...task, subtasks: task.subtasks ?? [] });
+    expanded.value = [...expanded.value, task.id];
+  }
 
   function openAddSubTaskDialog(task) {
     currentTaskForSubtask.value = task;
@@ -346,11 +403,13 @@
 
   function handleSubTaskCreated(newSubtask) {
     const task = tasks.value.find(
-      (t) => t.id === currentTaskForSubtask.value.id
+      (t) => t.id === currentTaskForSubtask.value.id,
     );
-    if (task) {
-      task.subtasks.push(newSubtask);
-    }
+    if (task)
+      task.subtasks.push({
+        ...newSubtask,
+        time_entries: newSubtask.time_entries ?? [],
+      });
   }
 
   onBeforeUnmount(() => {

--- a/gui/pages/time-tracking.vue
+++ b/gui/pages/time-tracking.vue
@@ -154,9 +154,9 @@
                   :key="entry.id"
                   class="flex items-center justify-between rounded-lg bg-muted px-3 py-2 text-sm">
                   <span
-                    >{{ formatTime(entry.clock_in) }} –
+                    >{{ formatClock(entry.clock_in) }} –
                     {{
-                      entry.clock_out ? formatTime(entry.clock_out) : "ongoing"
+                      entry.clock_out ? formatClock(entry.clock_out) : "ongoing"
                     }}</span
                   >
                   <Icon
@@ -366,25 +366,8 @@
   function startClockInTimer() {
     if (clockInterval) clearInterval(clockInterval);
     clockInterval = setInterval(() => {
-      const diff = new Date() - clockInTime.value;
-      const hours = String(Math.floor(diff / 3600000)).padStart(2, "0");
-      const minutes = String(Math.floor((diff % 3600000) / 60000)).padStart(
-        2,
-        "0",
-      );
-      const seconds = String(Math.floor((diff % 60000) / 1000)).padStart(
-        2,
-        "0",
-      );
-      clockInDuration.value = `${hours}:${minutes}:${seconds}`;
+      clockInDuration.value = formatDuration(new Date() - clockInTime.value);
     }, 1000);
-  }
-
-  function formatTime(value) {
-    return new Date(value).toLocaleTimeString([], {
-      hour: "2-digit",
-      minute: "2-digit",
-    });
   }
 
   function openAddTaskDialog() {

--- a/gui/plugins/theme.client.js
+++ b/gui/plugins/theme.client.js
@@ -1,0 +1,5 @@
+// Apply the persisted (or system-preferred) theme as early as possible on load.
+export default defineNuxtPlugin(() => {
+  const { init } = useTheme();
+  init();
+});

--- a/gui/tailwind.config.js
+++ b/gui/tailwind.config.js
@@ -1,0 +1,61 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  darkMode: "class",
+  theme: {
+    extend: {
+      colors: {
+        border: "rgb(var(--border) / <alpha-value>)",
+        input: "rgb(var(--input) / <alpha-value>)",
+        ring: "rgb(var(--ring) / <alpha-value>)",
+        background: "rgb(var(--background) / <alpha-value>)",
+        foreground: "rgb(var(--foreground) / <alpha-value>)",
+        card: {
+          DEFAULT: "rgb(var(--card) / <alpha-value>)",
+          foreground: "rgb(var(--card-foreground) / <alpha-value>)",
+        },
+        muted: {
+          DEFAULT: "rgb(var(--muted) / <alpha-value>)",
+          foreground: "rgb(var(--muted-foreground) / <alpha-value>)",
+        },
+        primary: {
+          DEFAULT: "rgb(var(--primary) / <alpha-value>)",
+          foreground: "rgb(var(--primary-foreground) / <alpha-value>)",
+        },
+        accent: {
+          DEFAULT: "rgb(var(--accent) / <alpha-value>)",
+          foreground: "rgb(var(--accent-foreground) / <alpha-value>)",
+        },
+        danger: {
+          DEFAULT: "rgb(var(--danger) / <alpha-value>)",
+          foreground: "rgb(var(--danger-foreground) / <alpha-value>)",
+        },
+      },
+      fontFamily: {
+        sans: ["Inter", "ui-sans-serif", "system-ui", "sans-serif"],
+      },
+      borderRadius: {
+        xl: "0.875rem",
+        "2xl": "1.125rem",
+      },
+      boxShadow: {
+        soft: "0 1px 2px 0 rgb(15 23 42 / 0.04), 0 4px 16px -4px rgb(15 23 42 / 0.08)",
+        card: "0 1px 3px 0 rgb(15 23 42 / 0.06), 0 8px 24px -8px rgb(15 23 42 / 0.10)",
+      },
+      keyframes: {
+        "fade-in": {
+          from: { opacity: "0" },
+          to: { opacity: "1" },
+        },
+        "scale-in": {
+          from: { opacity: "0", transform: "translateY(8px) scale(0.98)" },
+          to: { opacity: "1", transform: "translateY(0) scale(1)" },
+        },
+      },
+      animation: {
+        "fade-in": "fade-in 0.18s ease-out",
+        "scale-in": "scale-in 0.18s ease-out",
+      },
+    },
+  },
+  plugins: [],
+};

--- a/gui/tests/time.test.js
+++ b/gui/tests/time.test.js
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "vitest";
+import { formatDuration, formatClock } from "../utils/time.js";
+
+describe("formatDuration", () => {
+  it("formats zero", () => {
+    expect(formatDuration(0)).toBe("00:00:00");
+  });
+
+  it("formats seconds only", () => {
+    expect(formatDuration(5_000)).toBe("00:00:05");
+  });
+
+  it("formats minutes and seconds", () => {
+    expect(formatDuration(90_000)).toBe("00:01:30");
+  });
+
+  it("formats an exact hour", () => {
+    expect(formatDuration(3_600_000)).toBe("01:00:00");
+  });
+
+  it("formats hours, minutes and seconds together", () => {
+    // 2h 3m 4s
+    expect(formatDuration((2 * 3600 + 3 * 60 + 4) * 1000)).toBe("02:03:04");
+  });
+
+  it("supports durations over 24 hours", () => {
+    expect(formatDuration(25 * 3600 * 1000)).toBe("25:00:00");
+  });
+
+  it("truncates sub-second milliseconds", () => {
+    expect(formatDuration(1_999)).toBe("00:00:01");
+  });
+
+  it("clamps negative values to zero", () => {
+    expect(formatDuration(-5_000)).toBe("00:00:00");
+  });
+});
+
+describe("formatClock", () => {
+  it("returns a locale-agnostic hh:mm style string", () => {
+    const result = formatClock(new Date("2026-06-22T09:05:00"));
+    expect(result).toMatch(/\d{1,2}:\d{2}/);
+  });
+
+  it("accepts an ISO string as input", () => {
+    expect(typeof formatClock("2026-06-22T09:05:00")).toBe("string");
+  });
+});

--- a/gui/utils/time.js
+++ b/gui/utils/time.js
@@ -1,0 +1,24 @@
+// Pure time-formatting helpers, kept framework-free so they're easy to unit test.
+// Auto-imported across the app by Nuxt (utils/ directory).
+
+/**
+ * Format a duration given in milliseconds as `HH:MM:SS`.
+ * Negative values are clamped to zero.
+ */
+export function formatDuration(ms) {
+  const totalSeconds = Math.max(0, Math.floor(ms / 1000));
+  const hours = String(Math.floor(totalSeconds / 3600)).padStart(2, "0");
+  const minutes = String(Math.floor((totalSeconds % 3600) / 60)).padStart(2, "0");
+  const seconds = String(totalSeconds % 60).padStart(2, "0");
+  return `${hours}:${minutes}:${seconds}`;
+}
+
+/**
+ * Format a date/timestamp as a short local clock time (e.g. `14:05`).
+ */
+export function formatClock(value) {
+  return new Date(value).toLocaleTimeString([], {
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}

--- a/gui/vitest.config.js
+++ b/gui/vitest.config.js
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["tests/**/*.test.js"],
+  },
+});

--- a/gui/vuetify.options.ts
+++ b/gui/vuetify.options.ts
@@ -1,6 +1,0 @@
-// vuetify.config.ts
-import { defineVuetifyConfiguration } from 'vuetify-nuxt-module/custom-configuration'
-
-export default defineVuetifyConfiguration({
-    /* vuetify options */
-})


### PR DESCRIPTION
# Frontend restructure: drop Vuetify, rebuild on Tailwind CSS

## Summary

Full revamp of the frontend foundation. Vuetify is removed and the UI is rebuilt on **Tailwind CSS** with a custom design system, while keeping Nuxt 3 and all the existing auth/API plumbing. The app keeps working end to end; the time-tracking flow is preserved, just redesigned. New placeholder pages set up the target navigation (Dashboard, Calendar) for upcoming work.

## What changed

### Tooling & design system
- Removed `vuetify-nuxt-module`; added `@nuxtjs/tailwindcss`, `@nuxt/icon` (Lucide icons **bundled locally**, no runtime fetch) and `jwt-decode` as an explicit dependency.
- Design tokens (light/dark) via CSS variables in `assets/css/tailwind.css` and `tailwind.config.js`, built around the existing brand colors.
- Light/dark theme support: `useTheme` composable + client plugin, persisted to `localStorage` and respecting the system preference.

### UI components
- New Tailwind primitives under `components/ui/`: `Button`, `Card`, `Input`, `Textarea`, `Modal`, `Alert`, `ThemeToggle`.

### App shell & pages
- Rebuilt layouts to use proper `<slot/>`, a responsive sidebar with the target information architecture, and a redesigned public header.
- Migrated landing, login, overview and **time-tracking** (clock-in/out logic unchanged) to the new system; restyled the task/subtask dialogs.
- Added Dashboard and Calendar placeholder pages so the new nav resolves.

### Docs & CI
- Updated the README to reflect the Tailwind stack and corrected the setup commands (`manage.py` path, Celery, API docs URL).
- Test workflow now runs on **every branch push** instead of on pull requests.
- Fixed the CI Python matrix to `3.12`/`3.13` to match `requires-python >= 3.12` (3.10/3.11 would fail `uv sync`).
- Added `gui/.env.example`.

## Notes
- No backend/API behavior changed.
- Dashboard, Calendar and History are intentionally placeholders — wired up in a follow-up branch (`CalendarEvent` model + aggregation endpoints).