### PR TITLE
Dashboard

### DIFF
--- a/gui/components/dashboard/StatCard.vue
+++ b/gui/components/dashboard/StatCard.vue
@@ -1,0 +1,29 @@
+<template>
+  <UiCard>
+    <div class="flex items-start justify-between gap-3">
+      <div class="min-w-0">
+        <p class="truncate text-sm font-medium text-muted-foreground">
+          {{ label }}
+        </p>
+        <p class="mt-1 text-2xl font-bold tracking-tight">{{ value }}</p>
+        <p v-if="hint" class="mt-0.5 truncate text-xs text-muted-foreground">
+          {{ hint }}
+        </p>
+      </div>
+      <div
+        v-if="icon"
+        class="flex size-10 shrink-0 items-center justify-center rounded-xl bg-primary/10 text-primary">
+        <Icon :name="icon" class="size-5" />
+      </div>
+    </div>
+  </UiCard>
+</template>
+
+<script setup>
+  defineProps({
+    label: { type: String, required: true },
+    value: { type: [String, Number], default: "—" },
+    hint: { type: String, default: "" },
+    icon: { type: String, default: "" },
+  });
+</script>

--- a/gui/components/dashboard/TaskBreakdown.vue
+++ b/gui/components/dashboard/TaskBreakdown.vue
@@ -1,0 +1,88 @@
+<template>
+  <div v-if="tasks.length" class="space-y-4">
+    <div v-for="(task, index) in tasks" :key="task.task_id">
+      <div class="flex items-center gap-2">
+        <button
+          v-if="task.subtasks.length"
+          class="rounded-md p-0.5 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+          :aria-label="
+            expanded.has(task.task_id) ? 'Collapse subtasks' : 'Expand subtasks'
+          "
+          @click="toggle(task.task_id)">
+          <Icon
+            name="lucide:chevron-right"
+            class="size-4 transition-transform"
+            :class="{ 'rotate-90': expanded.has(task.task_id) }" />
+        </button>
+        <span v-else class="size-5 shrink-0"></span>
+
+        <span
+          class="size-2.5 shrink-0 rounded-full"
+          :style="{ backgroundColor: chartColor(index) }"></span>
+        <span class="min-w-0 flex-1 truncate text-sm font-medium">{{
+          task.task_name
+        }}</span>
+        <span class="shrink-0 text-sm font-semibold tabular-nums">
+          {{ formatHours(task.hours) }}
+        </span>
+      </div>
+
+      <div class="ml-7 mt-1.5 h-2 overflow-hidden rounded-full bg-muted">
+        <div
+          class="h-full rounded-full transition-all"
+          :style="{
+            width: `${pct(task.hours)}%`,
+            backgroundColor: chartColor(index),
+          }"></div>
+      </div>
+
+      <div v-if="expanded.has(task.task_id)" class="ml-7 mt-2.5 space-y-2">
+        <div
+          v-for="subtask in task.subtasks"
+          :key="subtask.subtask_id"
+          class="flex items-center gap-3">
+          <span class="min-w-0 flex-1 truncate text-xs text-muted-foreground">
+            {{ subtask.subtask_name }}
+          </span>
+          <div
+            class="h-1.5 w-24 shrink-0 overflow-hidden rounded-full bg-muted">
+            <div
+              class="h-full rounded-full bg-muted-foreground/50"
+              :style="{ width: `${pct(subtask.hours)}%` }"></div>
+          </div>
+          <span
+            class="w-14 shrink-0 text-right text-xs tabular-nums text-muted-foreground">
+            {{ formatHours(subtask.hours) }}
+          </span>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <p v-else class="py-8 text-center text-sm text-muted-foreground">
+    No tracked time in this range.
+  </p>
+</template>
+
+<script setup>
+  import { computed, reactive } from "vue";
+
+  const props = defineProps({
+    tasks: { type: Array, default: () => [] },
+  });
+
+  const expanded = reactive(new Set());
+
+  const maxHours = computed(() =>
+    Math.max(1, ...props.tasks.map((t) => t.hours)),
+  );
+
+  function pct(hours) {
+    return Math.min(100, (hours / maxHours.value) * 100);
+  }
+
+  function toggle(taskId) {
+    if (expanded.has(taskId)) expanded.delete(taskId);
+    else expanded.add(taskId);
+  }
+</script>

--- a/gui/components/dashboard/TrendChart.vue
+++ b/gui/components/dashboard/TrendChart.vue
@@ -1,0 +1,190 @@
+<template>
+  <div>
+    <div class="relative">
+      <svg
+        :viewBox="`0 0 ${W} ${H}`"
+        class="h-auto w-full"
+        preserveAspectRatio="xMidYMid meet"
+        role="img"
+        :aria-label="`Tracked hours per ${bucket} and task`">
+        <!-- Horizontal gridlines + y-axis labels -->
+        <g>
+          <line
+            v-for="tick in geometry.yTicks"
+            :key="`grid-${tick.value}`"
+            :x1="PAD.left"
+            :x2="W - PAD.right"
+            :y1="tick.y"
+            :y2="tick.y"
+            class="stroke-border"
+            stroke-width="1" />
+          <text
+            v-for="tick in geometry.yTicks"
+            :key="`ylabel-${tick.value}`"
+            :x="PAD.left - 8"
+            :y="tick.y + 3"
+            text-anchor="end"
+            class="fill-muted-foreground text-[10px]">
+            {{ tick.value }}
+          </text>
+        </g>
+
+        <!-- One line per visible task -->
+        <g v-for="line in geometry.lines" :key="`line-${line.taskId}`">
+          <path
+            :d="line.path"
+            fill="none"
+            :stroke="line.color"
+            stroke-width="2"
+            stroke-linejoin="round"
+            stroke-linecap="round" />
+          <circle
+            v-for="point in line.dots"
+            :key="`${line.taskId}-${point.i}`"
+            :cx="point.x"
+            :cy="point.y"
+            r="2.5"
+            :fill="line.color"
+            stroke-width="1.5"
+            class="stroke-card">
+            <title>{{ line.name }} · {{ point.tooltip }}</title>
+          </circle>
+        </g>
+
+        <!-- X-axis labels -->
+        <text
+          v-for="label in geometry.xLabels"
+          :key="`xlabel-${label.period_start}`"
+          :x="label.x"
+          :y="H - 8"
+          text-anchor="middle"
+          class="fill-muted-foreground text-[10px]">
+          {{ label.text }}
+        </text>
+      </svg>
+
+      <div
+        v-if="geometry.message"
+        class="pointer-events-none absolute inset-0 flex items-center justify-center">
+        <p class="text-sm text-muted-foreground">{{ geometry.message }}</p>
+      </div>
+    </div>
+
+    <!-- Legend: click to show/hide a task's line -->
+    <div v-if="tasks.length" class="mt-3 flex flex-wrap gap-x-4 gap-y-1.5">
+      <button
+        v-for="entry in legend"
+        :key="entry.taskId"
+        class="flex items-center gap-1.5 text-xs font-medium transition-colors"
+        :class="entry.hidden ? 'text-muted-foreground/60' : 'text-foreground'"
+        :title="entry.hidden ? 'Show this task' : 'Hide this task'"
+        @click="toggle(entry.taskId)">
+        <span
+          class="size-2.5 rounded-full transition-opacity"
+          :style="{
+            backgroundColor: entry.color,
+            opacity: entry.hidden ? 0.3 : 1,
+          }"></span>
+        <span :class="{ 'line-through': entry.hidden }">{{ entry.name }}</span>
+        <span class="text-muted-foreground">{{
+          formatHours(entry.hours)
+        }}</span>
+      </button>
+    </div>
+  </div>
+</template>
+
+<script setup>
+  import { computed, reactive } from "vue";
+
+  const props = defineProps({
+    buckets: { type: Array, default: () => [] },
+    tasks: { type: Array, default: () => [] },
+    bucket: { type: String, default: "day" },
+  });
+
+  const W = 720;
+  const H = 240;
+  const PAD = { top: 16, right: 16, bottom: 28, left: 36 };
+  const innerW = W - PAD.left - PAD.right;
+  const innerH = H - PAD.top - PAD.bottom;
+  const TICKS = 4;
+
+  const hidden = reactive(new Set());
+
+  function toggle(taskId) {
+    if (hidden.has(taskId)) hidden.delete(taskId);
+    else hidden.add(taskId);
+  }
+
+  const legend = computed(() =>
+    props.tasks.map((task, index) => ({
+      taskId: task.task_id,
+      name: task.task_name,
+      hours: task.hours,
+      color: chartColor(index),
+      hidden: hidden.has(task.task_id),
+    })),
+  );
+
+  const geometry = computed(() => {
+    const n = props.buckets.length;
+    const visible = props.tasks
+      .map((task, index) => ({ task, color: chartColor(index) }))
+      .filter(({ task }) => !hidden.has(task.task_id));
+
+    const maxValue = Math.max(
+      0,
+      ...visible.flatMap(({ task }) => task.series || []),
+    );
+    const niceMax = niceCeil(maxValue);
+
+    const xAt = (i) =>
+      n <= 1 ? PAD.left + innerW / 2 : PAD.left + (i / (n - 1)) * innerW;
+    const yAt = (h) => PAD.top + innerH - (h / niceMax) * innerH;
+
+    const lines = visible.map(({ task, color }) => {
+      const points = (task.series || []).map((hours, i) => ({
+        i,
+        x: xAt(i),
+        y: yAt(hours),
+        hours,
+        tooltip: `${labelAt(i)}: ${formatHours(hours)}`,
+      }));
+      return {
+        taskId: task.task_id,
+        name: task.task_name,
+        color,
+        path: points
+          .map((p, i) => `${i ? "L" : "M"}${p.x.toFixed(1)} ${p.y.toFixed(1)}`)
+          .join(" "),
+        dots: points.filter((p) => p.hours > 0),
+      };
+    });
+
+    const yTicks = Array.from({ length: TICKS + 1 }, (_, k) => {
+      const value = (niceMax / TICKS) * k;
+      return { value: Math.round(value * 10) / 10, y: yAt(value) };
+    });
+
+    const labelEvery = Math.max(1, Math.ceil(n / 6));
+    const xLabels = props.buckets
+      .map((b, i) => ({
+        x: xAt(i),
+        period_start: b.period_start,
+        text: labelAt(i),
+      }))
+      .filter((_, i) => i % labelEvery === 0 || i === n - 1);
+
+    let message = "";
+    if (!props.tasks.length) message = "No tracked time in this range.";
+    else if (!visible.length) message = "All tasks hidden.";
+
+    return { lines, yTicks, xLabels, message };
+  });
+
+  function labelAt(i) {
+    const b = props.buckets[i];
+    return b ? formatBucketLabel(b.period_start, props.bucket) : "";
+  }
+</script>

--- a/gui/pages/dashboard.vue
+++ b/gui/pages/dashboard.vue
@@ -7,28 +7,164 @@
       </p>
     </div>
 
-    <UiCard>
-      <div class="flex flex-col items-center gap-3 py-16 text-center">
-        <div
-          class="flex size-14 items-center justify-center rounded-2xl bg-muted text-muted-foreground">
-          <Icon name="lucide:chart-column" class="size-7" />
+    <UiAlert v-if="error" variant="danger">
+      Couldn't load your dashboard. Please try again.
+    </UiAlert>
+
+    <!-- Stat cards -->
+    <div class="grid grid-cols-2 gap-4 lg:grid-cols-4">
+      <DashboardStatCard
+        v-for="card in statCards"
+        :key="card.label"
+        :label="card.label"
+        :value="card.value"
+        :hint="card.hint"
+        :icon="card.icon" />
+    </div>
+
+    <!-- Charts -->
+    <div class="grid gap-6 lg:grid-cols-3">
+      <UiCard class="lg:col-span-2">
+        <template #header>
+          <h3 class="text-base font-semibold tracking-tight">
+            Tracked hours by task
+          </h3>
+          <p class="mt-0.5 text-sm text-muted-foreground">{{ rangeLabel }}</p>
+        </template>
+        <template #actions>
+          <div class="inline-flex rounded-xl border border-border p-0.5">
+            <button
+              v-for="option in BUCKET_OPTIONS"
+              :key="option.value"
+              class="rounded-lg px-3 py-1 text-sm font-medium transition-colors"
+              :class="
+                bucket === option.value
+                  ? 'bg-primary text-primary-foreground shadow-soft'
+                  : 'text-muted-foreground hover:text-foreground'
+              "
+              @click="bucket = option.value">
+              {{ option.label }}
+            </button>
+          </div>
+        </template>
+
+        <div class="relative min-h-[240px]">
+          <div
+            v-if="seriesLoading"
+            class="absolute inset-0 z-10 flex items-center justify-center rounded-xl bg-card/60 backdrop-blur-sm">
+            <Icon
+              name="lucide:loader-circle"
+              class="size-6 animate-spin text-muted-foreground" />
+          </div>
+          <DashboardTrendChart
+            :buckets="series?.buckets || []"
+            :tasks="series?.by_task || []"
+            :bucket="bucket" />
         </div>
-        <div>
-          <p class="font-semibold">Coming soon</p>
-          <p class="mt-1 max-w-sm text-sm text-muted-foreground">
-            Charts of time per task, trends over time, and summary stats will
-            live here.
-          </p>
+      </UiCard>
+
+      <UiCard title="Hours per task" subtitle="In the selected range">
+        <div class="relative min-h-[240px]">
+          <div
+            v-if="seriesLoading"
+            class="absolute inset-0 z-10 flex items-center justify-center rounded-xl bg-card/60 backdrop-blur-sm">
+            <Icon
+              name="lucide:loader-circle"
+              class="size-6 animate-spin text-muted-foreground" />
+          </div>
+          <DashboardTaskBreakdown :tasks="series?.by_task || []" />
         </div>
-      </div>
-    </UiCard>
+      </UiCard>
+    </div>
   </div>
 </template>
 
 <script setup>
+  import { ref, computed, watch, onMounted } from "vue";
+
   definePageMeta({
     middleware: "auth",
     requiresAuth: true,
     layout: "defaultlogged",
   });
+
+  const { $api } = useNuxtApp();
+
+  const bucket = ref("day");
+  const summary = ref(null);
+  const series = ref(null);
+  const seriesLoading = ref(false);
+  const error = ref(false);
+
+  const statCards = computed(() => {
+    const s = summary.value;
+    return [
+      {
+        label: "Today",
+        value: s ? formatHours(s.today_hours) : "—",
+        icon: "lucide:clock",
+      },
+      {
+        label: "This week",
+        value: s ? formatHours(s.week_hours) : "—",
+        icon: "lucide:calendar-days",
+      },
+      {
+        label: "Total tracked",
+        value: s ? formatHours(s.total_hours) : "—",
+        icon: "lucide:hourglass",
+      },
+      {
+        label: "Active tasks",
+        value: s ? s.active_tasks : "—",
+        hint: "worked on this week",
+        icon: "lucide:list-checks",
+      },
+    ];
+  });
+
+  const rangeLabel = computed(() => {
+    if (!series.value) return "";
+    const fmt = (d) =>
+      new Date(d).toLocaleDateString([], {
+        month: "short",
+        day: "numeric",
+        year: "numeric",
+      });
+    return `${fmt(series.value.start)} – ${fmt(series.value.end)}`;
+  });
+
+  async function loadSummary() {
+    try {
+      summary.value = await $api("/dashboard/user/get-summary/", {
+        method: "GET",
+      });
+    } catch (err) {
+      console.error("Error loading dashboard summary:", err);
+      error.value = true;
+    }
+  }
+
+  async function loadSeries() {
+    seriesLoading.value = true;
+    try {
+      const { start, end } = rangeForBucket(bucket.value);
+      series.value = await $api("/dashboard/user/get-time-series/", {
+        method: "GET",
+        query: {
+          start: start.toISOString(),
+          end: end.toISOString(),
+          bucket: bucket.value,
+        },
+      });
+    } catch (err) {
+      console.error("Error loading dashboard series:", err);
+      error.value = true;
+    } finally {
+      seriesLoading.value = false;
+    }
+  }
+
+  onMounted(loadSummary);
+  watch(bucket, loadSeries, { immediate: true });
 </script>

--- a/gui/tests/dashboard.test.js
+++ b/gui/tests/dashboard.test.js
@@ -1,0 +1,92 @@
+import { describe, it, expect } from "vitest";
+import {
+  formatHours,
+  rangeForBucket,
+  formatBucketLabel,
+  chartColor,
+  niceCeil,
+  BUCKET_OPTIONS,
+  CHART_COLORS,
+} from "../utils/dashboard.js";
+
+describe("formatHours", () => {
+  it("renders zero and negatives as 0h", () => {
+    expect(formatHours(0)).toBe("0h");
+    expect(formatHours(-3)).toBe("0h");
+    expect(formatHours(null)).toBe("0h");
+  });
+
+  it("combines hours and minutes", () => {
+    expect(formatHours(2.5)).toBe("2h 30m");
+  });
+
+  it("drops the minutes part on whole hours", () => {
+    expect(formatHours(3)).toBe("3h");
+  });
+
+  it("drops the hours part below one hour", () => {
+    expect(formatHours(0.75)).toBe("45m");
+  });
+
+  it("rounds to the nearest minute", () => {
+    expect(formatHours(1 / 60 + 0.0001)).toBe("1m");
+  });
+});
+
+describe("rangeForBucket", () => {
+  it("returns a trailing window starting at midnight days ago", () => {
+    const now = new Date(2026, 5, 22, 14, 30); // 2026-06-22 14:30 local
+    const { start, end } = rangeForBucket("day", now);
+    expect(end).toEqual(now);
+    expect(start.getHours()).toBe(0);
+    expect(start.getMinutes()).toBe(0);
+    // 30 days before the 22nd of June is the 23rd of May.
+    expect(start.getMonth()).toBe(4);
+    expect(start.getDate()).toBe(23);
+  });
+
+  it("uses a longer window for weekly and monthly buckets", () => {
+    const now = new Date(2026, 5, 22);
+    const days = (b) => Math.round((now - rangeForBucket(b, now).start) / 86400000);
+    expect(days("week")).toBeGreaterThan(days("day"));
+    expect(days("month")).toBeGreaterThan(days("week"));
+  });
+
+  it("falls back to the first bucket for an unknown value", () => {
+    const now = new Date(2026, 5, 22);
+    expect(rangeForBucket("nope", now)).toEqual(rangeForBucket(BUCKET_OPTIONS[0].value, now));
+  });
+});
+
+describe("formatBucketLabel", () => {
+  it("includes the day for day and week buckets", () => {
+    expect(formatBucketLabel("2026-03-09", "day")).toMatch(/9/);
+    expect(formatBucketLabel("2026-03-09", "week")).toMatch(/9/);
+  });
+
+  it("omits the day for month buckets", () => {
+    expect(formatBucketLabel("2026-03-01", "month")).not.toMatch(/\b1\b/);
+  });
+});
+
+describe("chartColor", () => {
+  it("cycles through the palette", () => {
+    expect(chartColor(0)).toBe(CHART_COLORS[0]);
+    expect(chartColor(CHART_COLORS.length)).toBe(CHART_COLORS[0]);
+  });
+});
+
+describe("niceCeil", () => {
+  it("never returns less than one", () => {
+    expect(niceCeil(0)).toBe(1);
+    expect(niceCeil(-5)).toBe(1);
+    expect(niceCeil(0.3)).toBe(0.5);
+  });
+
+  it("rounds up to 1, 2 or 5 times a power of ten", () => {
+    expect(niceCeil(3.2)).toBe(5);
+    expect(niceCeil(7)).toBe(10);
+    expect(niceCeil(12)).toBe(20);
+    expect(niceCeil(1)).toBe(1);
+  });
+});

--- a/gui/utils/dashboard.js
+++ b/gui/utils/dashboard.js
@@ -1,0 +1,79 @@
+// Pure helpers for the dashboard view: hours formatting, chart geometry and
+// the date ranges behind each bucket granularity. Kept framework-free so they
+// are easy to unit test. Auto-imported across the app by Nuxt (utils/).
+
+/**
+ * Format decimal hours (e.g. 2.5) as a compact `Xh Ym` label.
+ * 0 renders as `0h`; sub-hour values drop the hour part (`45m`).
+ */
+export function formatHours(hours) {
+  const totalMinutes = Math.round((Number(hours) || 0) * 60);
+  if (totalMinutes <= 0) return "0h";
+  const h = Math.floor(totalMinutes / 60);
+  const m = totalMinutes % 60;
+  if (h && m) return `${h}h ${m}m`;
+  if (h) return `${h}h`;
+  return `${m}m`;
+}
+
+/** Bucket granularities offered by the dashboard, each with its trailing window. */
+export const BUCKET_OPTIONS = [
+  { value: "day", label: "Daily", days: 30 },
+  { value: "week", label: "Weekly", days: 7 * 12 },
+  { value: "month", label: "Monthly", days: 365 },
+];
+
+/**
+ * Returns the `{ start, end }` Date range to request for a given bucket: a
+ * trailing window ending now and starting at midnight `days` ago.
+ */
+export function rangeForBucket(bucket, now = new Date()) {
+  const option =
+    BUCKET_OPTIONS.find((b) => b.value === bucket) || BUCKET_OPTIONS[0];
+  const start = new Date(now);
+  start.setDate(start.getDate() - option.days);
+  start.setHours(0, 0, 0, 0);
+  return { start, end: new Date(now) };
+}
+
+/**
+ * Format a bucket's `period_start` (an ISO `YYYY-MM-DD` date) as a short axis
+ * label. Parsed as local time so the label never drifts by a day.
+ */
+export function formatBucketLabel(periodStart, bucket) {
+  const date = new Date(`${periodStart}T00:00:00`);
+  if (bucket === "month") {
+    return date.toLocaleDateString([], { month: "short", year: "2-digit" });
+  }
+  return date.toLocaleDateString([], { month: "short", day: "numeric" });
+}
+
+/** A small qualitative palette for the per-task bars, cycled by index. */
+export const CHART_COLORS = [
+  "#007CBF",
+  "#5EA611",
+  "#D30F4B",
+  "#9333EA",
+  "#F59E0B",
+  "#0EA5E9",
+  "#14B8A6",
+  "#EC4899",
+];
+
+/** Returns a stable color for the chart series at position `index`. */
+export function chartColor(index) {
+  return CHART_COLORS[index % CHART_COLORS.length];
+}
+
+/**
+ * Rounds a value up to a visually "nice" axis maximum (1, 2 or 5 times a power
+ * of ten), so chart gridlines land on readable numbers. Always >= 1.
+ */
+export function niceCeil(value) {
+  if (!value || value <= 0) return 1;
+  const power = Math.pow(10, Math.floor(Math.log10(value)));
+  const normalized = value / power;
+  const nice =
+    normalized <= 1 ? 1 : normalized <= 2 ? 2 : normalized <= 5 ? 5 : 10;
+  return nice * power;
+}

--- a/ticktask/api.py
+++ b/ticktask/api.py
@@ -7,9 +7,11 @@ from ticktask.server.routes.auth import auth_router
 
 from ticktask.server.routes.tasks import ticktask_router
 from ticktask.server.routes.calendar import calendar_router
+from ticktask.server.routes.dashboard import dashboard_router
 
 api = NinjaAPI()
 
 api.add_router("/auth/", auth_router)
 api.add_router("/ticktask/", ticktask_router)
 api.add_router("/calendar/", calendar_router)
+api.add_router("/dashboard/", dashboard_router)

--- a/ticktask/server/routes/dashboard.py
+++ b/ticktask/server/routes/dashboard.py
@@ -1,0 +1,202 @@
+"""
+Endpoints that aggregate the user's tracked time for the dashboard: a
+headline summary for the stat cards and a bucketed time series (plus a
+per-task / per-subtask breakdown) for the charts.
+
+Aggregation is done in Python over the closed time entries. Following
+``TimeEntry.get_time_dedicated``, only entries with a ``clock_out`` count,
+and each entry is attributed to the bucket its ``clock_in`` falls in.
+"""
+
+import os
+from datetime import date, datetime, timedelta
+
+import django
+from ninja import Router
+from ninja.errors import HttpError
+from ninja_jwt.authentication import JWTAuth
+
+from ticktask.server.schemas.dashboard_schema import (
+    DashboardSummarySchema,
+    TimeSeriesSchema,
+)
+
+try:
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "ticktask.settings")
+    django.setup()
+except RuntimeError:
+    pass
+
+from django.utils import timezone
+from ticktask.models import TimeEntry
+
+dashboard_router = Router()
+
+_BUCKETS = ("day", "week", "month")
+
+
+def _hours(delta: timedelta) -> float:
+    """Converts a duration to decimal hours rounded to 4 decimals."""
+    return round(delta.total_seconds() / 3600, 4)
+
+
+def _bucket_start(day: date, bucket: str) -> date:
+    """Returns the date the bucket containing ``day`` starts on."""
+    if bucket == "week":
+        return day - timedelta(days=day.weekday())
+    if bucket == "month":
+        return day.replace(day=1)
+    return day
+
+
+def _next_bucket(day: date, bucket: str) -> date:
+    """Returns the start date of the bucket following the one at ``day``."""
+    if bucket == "week":
+        return day + timedelta(days=7)
+    if bucket == "month":
+        return (day.replace(day=28) + timedelta(days=4)).replace(day=1)
+    return day + timedelta(days=1)
+
+
+def _iter_buckets(start: date, end: date, bucket: str):
+    """Yields every bucket start from ``start`` to ``end`` inclusive."""
+    current = _bucket_start(start, bucket)
+    last = _bucket_start(end, bucket)
+    while current <= last:
+        yield current
+        current = _next_bucket(current, bucket)
+
+
+@dashboard_router.get(
+    "/user/get-summary/",
+    response=DashboardSummarySchema,
+    tags=["Dashboard"],
+    auth=JWTAuth(),
+)
+def get_summary(request):
+    """
+    Returns the headline hours for the stat cards: time tracked today, this
+    week, this month and overall, plus the number of tasks worked on this
+    week. Windows are relative to the current UTC instant and entries are
+    attributed by their ``clock_in``.
+    """
+    now = timezone.now()
+    today_start = now.replace(hour=0, minute=0, second=0, microsecond=0)
+    week_start = today_start - timedelta(days=today_start.weekday())
+    month_start = today_start.replace(day=1)
+
+    today = week = month = total = timedelta()
+    entries = TimeEntry.objects.filter(  # pylint: disable=no-member
+        subtask__task__user=request.auth, clock_out__isnull=False
+    ).values("clock_in", "clock_out")
+    for entry in entries:
+        duration = entry["clock_out"] - entry["clock_in"]
+        total += duration
+        clock_in = entry["clock_in"]
+        if clock_in >= today_start:
+            today += duration
+        if clock_in >= week_start:
+            week += duration
+        if clock_in >= month_start:
+            month += duration
+
+    # "Active" means worked on this week, so an entry still open counts too.
+    active_tasks = (
+        TimeEntry.objects.filter(  # pylint: disable=no-member
+            subtask__task__user=request.auth, clock_in__gte=week_start
+        )
+        .values("subtask__task_id")
+        .distinct()
+        .count()
+    )
+
+    return {
+        "today_hours": _hours(today),
+        "week_hours": _hours(week),
+        "month_hours": _hours(month),
+        "total_hours": _hours(total),
+        "active_tasks": active_tasks,
+    }
+
+
+@dashboard_router.get(
+    "/user/get-time-series/",
+    response=TimeSeriesSchema,
+    tags=["Dashboard"],
+    auth=JWTAuth(),
+)
+def get_time_series(request, start: datetime, end: datetime, bucket: str = "day"):
+    """
+    Returns the tracked hours within ``[start, end]`` grouped into contiguous
+    ``bucket`` (``day``/``week``/``month``) buckets (zero-filled), together
+    with the per-task and per-subtask totals for the same range.
+    """
+    if bucket not in _BUCKETS:
+        raise HttpError(422, f"bucket must be one of {', '.join(_BUCKETS)}.")
+    if end < start:
+        raise HttpError(422, "end cannot be before start.")
+
+    entries = (
+        TimeEntry.objects.select_related("subtask__task")  # pylint: disable=no-member
+        .filter(
+            subtask__task__user=request.auth,
+            clock_out__isnull=False,
+            clock_in__gte=start,
+            clock_in__lte=end,
+        )
+        .order_by("clock_in")
+    )
+
+    bucket_totals: dict[date, timedelta] = {}
+    tasks: dict[int, dict] = {}
+    for entry in entries:
+        duration = entry.clock_out - entry.clock_in
+        key = _bucket_start(entry.clock_in.date(), bucket)
+        bucket_totals[key] = bucket_totals.get(key, timedelta()) + duration
+
+        subtask = entry.subtask
+        task = subtask.task
+        task_agg = tasks.setdefault(
+            task.id, {"name": task.name, "total": timedelta(), "subtasks": {}}
+        )
+        task_agg["total"] += duration
+        sub_agg = task_agg["subtasks"].setdefault(
+            subtask.id, {"name": subtask.name, "total": timedelta()}
+        )
+        sub_agg["total"] += duration
+
+    buckets = [
+        {"period_start": day, "hours": _hours(bucket_totals.get(day, timedelta()))}
+        for day in _iter_buckets(start.date(), end.date(), bucket)
+    ]
+
+    by_task = [
+        {
+            "task_id": task_id,
+            "task_name": agg["name"],
+            "hours": _hours(agg["total"]),
+            "subtasks": [
+                {
+                    "subtask_id": sub_id,
+                    "subtask_name": sub["name"],
+                    "hours": _hours(sub["total"]),
+                }
+                for sub_id, sub in sorted(
+                    agg["subtasks"].items(),
+                    key=lambda kv: kv[1]["total"],
+                    reverse=True,
+                )
+            ],
+        }
+        for task_id, agg in sorted(
+            tasks.items(), key=lambda kv: kv[1]["total"], reverse=True
+        )
+    ]
+
+    return {
+        "bucket": bucket,
+        "start": start,
+        "end": end,
+        "buckets": buckets,
+        "by_task": by_task,
+    }

--- a/ticktask/server/routes/dashboard.py
+++ b/ticktask/server/routes/dashboard.py
@@ -28,7 +28,7 @@ except RuntimeError:
     pass
 
 from django.utils import timezone
-from ticktask.models import TimeEntry
+from ticktask.models import Task, TimeEntry
 
 dashboard_router = Router()
 
@@ -157,17 +157,28 @@ def get_time_series(request, start: datetime, end: datetime, bucket: str = "day"
         subtask = entry.subtask
         task = subtask.task
         task_agg = tasks.setdefault(
-            task.id, {"name": task.name, "total": timedelta(), "subtasks": {}}
+            task.id,
+            {"name": task.name, "total": timedelta(), "buckets": {}, "subtasks": {}},
         )
         task_agg["total"] += duration
+        task_agg["buckets"][key] = task_agg["buckets"].get(key, timedelta()) + duration
         sub_agg = task_agg["subtasks"].setdefault(
             subtask.id, {"name": subtask.name, "total": timedelta()}
         )
         sub_agg["total"] += duration
 
+    # Include every task the user owns, so a task with no tracked time in the
+    # range still shows up (as a flat zero line) instead of disappearing.
+    for task in Task.objects.filter(user=request.auth):  # pylint: disable=no-member
+        tasks.setdefault(
+            task.id,
+            {"name": task.name, "total": timedelta(), "buckets": {}, "subtasks": {}},
+        )
+
+    bucket_keys = list(_iter_buckets(start.date(), end.date(), bucket))
     buckets = [
         {"period_start": day, "hours": _hours(bucket_totals.get(day, timedelta()))}
-        for day in _iter_buckets(start.date(), end.date(), bucket)
+        for day in bucket_keys
     ]
 
     by_task = [
@@ -175,6 +186,9 @@ def get_time_series(request, start: datetime, end: datetime, bucket: str = "day"
             "task_id": task_id,
             "task_name": agg["name"],
             "hours": _hours(agg["total"]),
+            "series": [
+                _hours(agg["buckets"].get(day, timedelta())) for day in bucket_keys
+            ],
             "subtasks": [
                 {
                     "subtask_id": sub_id,
@@ -189,7 +203,8 @@ def get_time_series(request, start: datetime, end: datetime, bucket: str = "day"
             ],
         }
         for task_id, agg in sorted(
-            tasks.items(), key=lambda kv: kv[1]["total"], reverse=True
+            tasks.items(),
+            key=lambda kv: (-kv[1]["total"].total_seconds(), kv[1]["name"].lower()),
         )
     ]
 

--- a/ticktask/server/schemas/dashboard_schema.py
+++ b/ticktask/server/schemas/dashboard_schema.py
@@ -42,11 +42,16 @@ class SubTaskHoursSchema(Schema):
 
 
 class TaskHoursSchema(Schema):
-    """Tracked hours for a task over the range, broken down by subtask."""
+    """
+    Tracked hours for a task over the range: the total, the per-bucket series
+    (aligned, in order, with the top-level ``buckets``) used to draw the task's
+    line, and the per-subtask breakdown.
+    """
 
     task_id: int
     task_name: str
     hours: float
+    series: list[float]
     subtasks: list[SubTaskHoursSchema]
 
 

--- a/ticktask/server/schemas/dashboard_schema.py
+++ b/ticktask/server/schemas/dashboard_schema.py
@@ -1,0 +1,63 @@
+"""
+Schemas for the dashboard aggregation endpoints (hours summary and the
+time series used to draw the charts).
+"""
+
+from datetime import date, datetime
+
+from ninja import Schema
+
+
+class DashboardSummarySchema(Schema):
+    """
+    Headline figures for the dashboard stat cards. Hours are decimal hours
+    (e.g. 1.5 == one hour and a half) and the windows are relative to the
+    current UTC instant.
+    """
+
+    today_hours: float
+    week_hours: float
+    month_hours: float
+    total_hours: float
+    active_tasks: int
+
+
+class TimeSeriesBucketSchema(Schema):
+    """
+    Total tracked hours within a single time bucket, keyed by the date the
+    bucket starts on (the day, the Monday of the week, or the 1st of the
+    month depending on the requested granularity).
+    """
+
+    period_start: date
+    hours: float
+
+
+class SubTaskHoursSchema(Schema):
+    """Tracked hours for a single subtask over the requested range."""
+
+    subtask_id: int
+    subtask_name: str
+    hours: float
+
+
+class TaskHoursSchema(Schema):
+    """Tracked hours for a task over the range, broken down by subtask."""
+
+    task_id: int
+    task_name: str
+    hours: float
+    subtasks: list[SubTaskHoursSchema]
+
+
+class TimeSeriesSchema(Schema):
+    """
+    The time series for a ``[start, end]`` range at a given bucket size,
+    together with the per-task / per-subtask breakdown for the same range.
+    """
+
+    bucket: str
+    start: datetime
+    end: datetime
+    buckets: list[TimeSeriesBucketSchema]
+    by_task: list[TaskHoursSchema]

--- a/ticktask/tests/test_dashboard.py
+++ b/ticktask/tests/test_dashboard.py
@@ -1,0 +1,265 @@
+"""
+Tests for the dashboard aggregation endpoints (summary + time series).
+"""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from django.test import Client
+from django.utils import timezone as dj_timezone
+from django.contrib.auth.models import User
+from ninja_jwt.tokens import RefreshToken
+
+from ticktask.models import Task, SubTask, TimeEntry
+
+BASE = "/api/dashboard/user"
+
+
+def make_user(username: str = "alice") -> User:
+    """Creates a user that owns the tracked time under test."""
+    return User.objects.create_user(username=username, password="pw")
+
+
+def auth_client(user: User) -> Client:
+    """Returns a Django test client authenticated as ``user`` via JWT."""
+    token = str(RefreshToken.for_user(user).access_token)
+    return Client(HTTP_AUTHORIZATION=f"Bearer {token}")
+
+
+def make_subtask(user: User, task_name: str, subtask_name: str) -> SubTask:
+    """Creates a task + subtask owned by ``user``."""
+    task, _ = Task.objects.get_or_create(user=user, name=task_name)  # pylint: disable=no-member
+    return SubTask.objects.create(  # pylint: disable=no-member
+        task=task, name=subtask_name, description="d"
+    )
+
+
+def make_entry(subtask: SubTask, clock_in: datetime, clock_out) -> TimeEntry:
+    """Creates a time entry with explicit clock_in/out (clock_in is auto_now_add)."""
+    entry = TimeEntry.objects.create(subtask=subtask)  # pylint: disable=no-member
+    TimeEntry.objects.filter(id=entry.id).update(  # pylint: disable=no-member
+        clock_in=clock_in, clock_out=clock_out
+    )
+    return entry
+
+
+def iso(dt: datetime) -> str:
+    """Serializes a datetime to ISO 8601."""
+    return dt.isoformat()
+
+
+# --------------------------------------------------------------------------- #
+# Summary
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.django_db
+def test_summary_aggregates_windows():
+    """Today/week/month include the recent entry; total also includes old time."""
+    user = make_user()
+    now = dj_timezone.now()
+    today_start = now.replace(hour=0, minute=0, second=0, microsecond=0)
+
+    recent = make_subtask(user, "Recent", "s")
+    old = make_subtask(user, "Old", "s")
+    # 30 min today (anchored to midnight, always inside today/week/month).
+    make_entry(recent, today_start, today_start + timedelta(minutes=30))
+    # 2 h, 100 days ago (only counts towards the all-time total).
+    old_in = today_start - timedelta(days=100)
+    make_entry(old, old_in, old_in + timedelta(hours=2))
+
+    resp = auth_client(user).get(f"{BASE}/get-summary/")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["today_hours"] == 0.5
+    assert body["week_hours"] == 0.5
+    assert body["month_hours"] == 0.5
+    assert body["total_hours"] == 2.5
+    # Only the task worked on this week is "active".
+    assert body["active_tasks"] == 1
+
+
+@pytest.mark.django_db
+def test_summary_ignores_open_entries_for_hours_but_counts_active():
+    """An open entry adds no hours but its task still counts as active."""
+    user = make_user()
+    today_start = dj_timezone.now().replace(hour=0, minute=0, second=0, microsecond=0)
+    subtask = make_subtask(user, "Live", "s")
+    make_entry(subtask, today_start, None)
+
+    body = auth_client(user).get(f"{BASE}/get-summary/").json()
+
+    assert body["total_hours"] == 0.0
+    assert body["active_tasks"] == 1
+
+
+@pytest.mark.django_db
+def test_summary_scoped_to_user():
+    """Another user's tracked time is never aggregated."""
+    user = make_user("alice")
+    other = make_user("bob")
+    today_start = dj_timezone.now().replace(hour=0, minute=0, second=0, microsecond=0)
+    make_entry(
+        make_subtask(other, "Theirs", "s"),
+        today_start,
+        today_start + timedelta(hours=1),
+    )
+
+    body = auth_client(user).get(f"{BASE}/get-summary/").json()
+
+    assert body["total_hours"] == 0.0
+    assert body["active_tasks"] == 0
+
+
+# --------------------------------------------------------------------------- #
+# Time series
+# --------------------------------------------------------------------------- #
+
+
+def _series(client, start, end, bucket=None):
+    params = {"start": iso(start), "end": iso(end)}
+    if bucket:
+        params["bucket"] = bucket
+    return client.get(f"{BASE}/get-time-series/", params)
+
+
+@pytest.mark.django_db
+def test_time_series_day_buckets_zero_filled():
+    """Daily buckets are contiguous and missing days are filled with zero."""
+    user = make_user()
+    subtask = make_subtask(user, "T", "s")
+    make_entry(
+        subtask,
+        datetime(2026, 3, 1, 9, tzinfo=timezone.utc),
+        datetime(2026, 3, 1, 10, tzinfo=timezone.utc),
+    )  # 1 h
+    make_entry(
+        subtask,
+        datetime(2026, 3, 3, 9, tzinfo=timezone.utc),
+        datetime(2026, 3, 3, 11, tzinfo=timezone.utc),
+    )  # 2 h
+
+    resp = _series(
+        auth_client(user),
+        datetime(2026, 3, 1, 0, tzinfo=timezone.utc),
+        datetime(2026, 3, 3, 23, 59, tzinfo=timezone.utc),
+        bucket="day",
+    )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["bucket"] == "day"
+    assert [(b["period_start"], b["hours"]) for b in body["buckets"]] == [
+        ("2026-03-01", 1.0),
+        ("2026-03-02", 0.0),
+        ("2026-03-03", 2.0),
+    ]
+
+
+@pytest.mark.django_db
+def test_time_series_by_task_breakdown_sorted():
+    """by_task aggregates per task/subtask and is sorted by hours desc."""
+    user = make_user()
+    sub_a = make_subtask(user, "Alpha", "a1")
+    sub_b = make_subtask(user, "Beta", "b1")
+    make_entry(
+        sub_a,
+        datetime(2026, 3, 1, 9, tzinfo=timezone.utc),
+        datetime(2026, 3, 1, 10, tzinfo=timezone.utc),
+    )  # Alpha 1 h
+    make_entry(
+        sub_b,
+        datetime(2026, 3, 1, 9, tzinfo=timezone.utc),
+        datetime(2026, 3, 1, 12, tzinfo=timezone.utc),
+    )  # Beta 3 h
+
+    body = _series(
+        auth_client(user),
+        datetime(2026, 3, 1, 0, tzinfo=timezone.utc),
+        datetime(2026, 3, 1, 23, tzinfo=timezone.utc),
+    ).json()
+
+    names = [(t["task_name"], t["hours"]) for t in body["by_task"]]
+    assert names == [("Beta", 3.0), ("Alpha", 1.0)]
+    beta = body["by_task"][0]
+    assert beta["subtasks"] == [
+        {"subtask_id": sub_b.id, "subtask_name": "b1", "hours": 3.0}
+    ]
+
+
+@pytest.mark.django_db
+def test_time_series_week_bucket_groups_same_week():
+    """Entries in the same ISO week collapse into one weekly bucket."""
+    user = make_user()
+    subtask = make_subtask(user, "T", "s")
+    # 2026-03-02 is a Monday; both entries fall in that week.
+    make_entry(
+        subtask,
+        datetime(2026, 3, 3, 9, tzinfo=timezone.utc),
+        datetime(2026, 3, 3, 10, tzinfo=timezone.utc),
+    )  # 1 h
+    make_entry(
+        subtask,
+        datetime(2026, 3, 5, 9, tzinfo=timezone.utc),
+        datetime(2026, 3, 5, 10, tzinfo=timezone.utc),
+    )  # 1 h
+
+    body = _series(
+        auth_client(user),
+        datetime(2026, 3, 2, 0, tzinfo=timezone.utc),
+        datetime(2026, 3, 6, 0, tzinfo=timezone.utc),
+        bucket="week",
+    ).json()
+
+    assert body["buckets"] == [{"period_start": "2026-03-02", "hours": 2.0}]
+
+
+@pytest.mark.django_db
+def test_time_series_rejects_invalid_bucket():
+    """An unknown bucket size is rejected."""
+    resp = _series(
+        auth_client(make_user()),
+        datetime(2026, 3, 1, 0, tzinfo=timezone.utc),
+        datetime(2026, 3, 2, 0, tzinfo=timezone.utc),
+        bucket="year",
+    )
+    assert resp.status_code == 422
+
+
+@pytest.mark.django_db
+def test_time_series_rejects_end_before_start():
+    """A range whose end precedes its start is rejected."""
+    resp = _series(
+        auth_client(make_user()),
+        datetime(2026, 3, 2, 0, tzinfo=timezone.utc),
+        datetime(2026, 3, 1, 0, tzinfo=timezone.utc),
+    )
+    assert resp.status_code == 422
+
+
+@pytest.mark.django_db
+def test_time_series_scoped_to_user():
+    """Another user's entries never appear in the series or breakdown."""
+    user = make_user("alice")
+    other = make_user("bob")
+    make_entry(
+        make_subtask(other, "Theirs", "s"),
+        datetime(2026, 3, 1, 9, tzinfo=timezone.utc),
+        datetime(2026, 3, 1, 10, tzinfo=timezone.utc),
+    )
+
+    body = _series(
+        auth_client(user),
+        datetime(2026, 3, 1, 0, tzinfo=timezone.utc),
+        datetime(2026, 3, 1, 23, tzinfo=timezone.utc),
+    ).json()
+
+    assert body["by_task"] == []
+    assert all(b["hours"] == 0.0 for b in body["buckets"])
+
+
+@pytest.mark.django_db
+def test_dashboard_requires_authentication():
+    """Unauthenticated requests are rejected."""
+    assert Client().get(f"{BASE}/get-summary/").status_code == 401

--- a/ticktask/tests/test_dashboard.py
+++ b/ticktask/tests/test_dashboard.py
@@ -189,6 +189,59 @@ def test_time_series_by_task_breakdown_sorted():
 
 
 @pytest.mark.django_db
+def test_time_series_per_task_series_aligns_with_buckets():
+    """Each task carries a per-bucket series aligned with the bucket axis."""
+    user = make_user()
+    subtask = make_subtask(user, "T", "s")
+    make_entry(subtask, datetime(2026, 3, 1, 9, tzinfo=timezone.utc),
+               datetime(2026, 3, 1, 10, tzinfo=timezone.utc))  # day 1: 1 h
+    make_entry(subtask, datetime(2026, 3, 3, 9, tzinfo=timezone.utc),
+               datetime(2026, 3, 3, 11, tzinfo=timezone.utc))  # day 3: 2 h
+
+    body = _series(
+        auth_client(user),
+        datetime(2026, 3, 1, 0, tzinfo=timezone.utc),
+        datetime(2026, 3, 3, 23, 59, tzinfo=timezone.utc),
+        bucket="day",
+    ).json()
+
+    assert [b["period_start"] for b in body["buckets"]] == [
+        "2026-03-01",
+        "2026-03-02",
+        "2026-03-03",
+    ]
+    assert len(body["by_task"]) == 1
+    # Series is aligned, in order, with the buckets above.
+    assert body["by_task"][0]["series"] == [1.0, 0.0, 2.0]
+
+
+@pytest.mark.django_db
+def test_time_series_includes_tasks_without_activity():
+    """Tasks with no tracked time in the range still appear, flat at zero."""
+    user = make_user()
+    active = make_subtask(user, "Active", "s")
+    make_entry(active, datetime(2026, 3, 1, 9, tzinfo=timezone.utc),
+               datetime(2026, 3, 1, 10, tzinfo=timezone.utc))  # 1 h
+    # A second task with no entries at all in the range.
+    Task.objects.create(user=user, name="Idle")  # pylint: disable=no-member
+
+    body = _series(
+        auth_client(user),
+        datetime(2026, 3, 1, 0, tzinfo=timezone.utc),
+        datetime(2026, 3, 2, 0, tzinfo=timezone.utc),
+        bucket="day",
+    ).json()
+
+    by_name = {t["task_name"]: t for t in body["by_task"]}
+    assert set(by_name) == {"Active", "Idle"}
+    # The active task ranks first; the idle one is present but all zeros.
+    assert body["by_task"][0]["task_name"] == "Active"
+    assert by_name["Idle"]["hours"] == 0.0
+    assert set(by_name["Idle"]["series"]) == {0.0}
+    assert by_name["Idle"]["subtasks"] == []
+
+
+@pytest.mark.django_db
 def test_time_series_week_bucket_groups_same_week():
     """Entries in the same ISO week collapse into one weekly bucket."""
     user = make_user()


### PR DESCRIPTION
## Dashboard feature

Adds the dashboard end-to-end (backend aggregation + frontend page), following the same vertical pattern as the calendar feature. Charts are built **from scratch** (no chart library) to keep full control over look and feel.

### Backend

- **Two aggregation endpoints** under `/api/dashboard/`, JWT-authed and scoped to `request.auth`, with `Schema`s in `server/schemas/dashboard_schema.py`:
  - `GET /dashboard/user/get-summary/` — headline figures for the stat cards: hours tracked today, this week, this month and overall, plus the number of tasks worked on this week. Windows are relative to the current UTC instant.
  - `GET /dashboard/user/get-time-series/?start&end&bucket=day|week|month` — contiguous, zero-filled buckets for the trend, plus a per-task / per-subtask breakdown. Each task carries its own `series` (hours per bucket, aligned in order with the top-level `buckets`) so the chart can draw one line per task. Validates the bucket size and `end >= start` (422).
- **Aggregation done in Python** over closed time entries. Consistent with `TimeEntry.get_time_dedicated`: only entries with a `clock_out` count, and each entry is attributed to the bucket its `clock_in` falls in.
- **Every task the user owns is included** in the breakdown, even with no tracked time in the range, so a task renders as a flat zero line instead of disappearing. Tasks are ordered by hours desc, then by name.
- New router mounted in `api.py`.

### Frontend

- **Dashboard page** (`pages/dashboard.vue`): four stat cards, a granularity control (Daily / Weekly / Monthly) that drives the requested range, and two chart cards. Loads `get-summary` once and `get-time-series` on bucket change, with loading / empty / error states.
- **Custom charts** (SVG / CSS, no library):
  - `TrendChart.vue` — multi-line trend, one line per task with a clickable legend to show/hide individual tasks; the Y-axis rescales to the visible tasks. "Nice" gridlines, per-point native tooltips, zero-fill and empty states.
  - `TaskBreakdown.vue` — horizontal bars per task with collapsible per-subtask breakdown.
  - `StatCard.vue` — a single stat card (label, value, icon, hint).
- **`utils/dashboard.js`** — pure helpers (`formatHours`, `rangeForBucket`, `formatBucketLabel`, `chartColor`, `niceCeil`, `BUCKET_OPTIONS`). Chart colors are shared between the trend lines, the legend and the breakdown so a task keeps the same color everywhere.