### PR TITLE
Cleanup and polish

### DIFF
--- a/gui/components/AddSubTaskDialog.vue
+++ b/gui/components/AddSubTaskDialog.vue
@@ -36,7 +36,7 @@
 
   const emit = defineEmits(["update:modelValue", "subtask-created"]);
 
-  const { $api } = useNuxtApp();
+  const { createSubtask } = useTasks();
 
   const dialog = ref(props.modelValue);
   const subtaskName = ref("");
@@ -67,14 +67,11 @@
 
     loading.value = true;
     try {
-      const response = await $api("/ticktask/user/create-subtask/", {
-        method: "POST",
-        body: {
-          name: subtaskName.value.trim(),
-          description: subtaskDescription.value.trim(),
-          task_id: props.taskId,
-        },
-      });
+      const response = await createSubtask(
+        props.taskId,
+        subtaskName.value.trim(),
+        subtaskDescription.value.trim(),
+      );
 
       emit("subtask-created", response);
       dialog.value = false;

--- a/gui/components/AddTaskDialog.vue
+++ b/gui/components/AddTaskDialog.vue
@@ -29,7 +29,7 @@
 
   const emit = defineEmits(["update:modelValue", "task-created"]);
 
-  const { $api } = useNuxtApp();
+  const { createTask } = useTasks();
 
   const dialog = ref(props.modelValue);
   const taskName = ref("");
@@ -57,10 +57,7 @@
 
     loading.value = true;
     try {
-      const response = await $api("/ticktask/user/create-task/", {
-        method: "POST",
-        body: { name: taskName.value.trim() },
-      });
+      const response = await createTask(taskName.value.trim());
 
       emit("task-created", response);
       dialog.value = false;

--- a/gui/components/EventDialog.vue
+++ b/gui/components/EventDialog.vue
@@ -16,10 +16,14 @@
 
       <div class="grid gap-4 sm:grid-cols-2">
         <UiInput v-model="startLocal" label="Start" type="datetime-local" />
-        <UiInput v-model="endLocal" label="End (optional)" type="datetime-local" />
+        <UiInput
+          v-model="endLocal"
+          label="End (optional)"
+          type="datetime-local" />
       </div>
 
-      <label class="flex w-fit cursor-pointer items-center gap-2 text-sm font-medium">
+      <label
+        class="flex w-fit cursor-pointer items-center gap-2 text-sm font-medium">
         <input
           v-model="allDay"
           type="checkbox"
@@ -73,9 +77,17 @@
 
   const emit = defineEmits(["update:modelValue", "saved", "deleted"]);
 
-  const { $api } = useNuxtApp();
+  const { createEvent, updateEvent, deleteEvent } = useCalendar();
+  const toast = useToast();
 
-  const presets = ["#007CBF", "#5EA611", "#D30F4B", "#F59E0B", "#7C3AED", "#0EA5E9"];
+  const presets = [
+    "#007CBF",
+    "#5EA611",
+    "#D30F4B",
+    "#F59E0B",
+    "#7C3AED",
+    "#0EA5E9",
+  ];
 
   const title = ref("");
   const description = ref("");
@@ -104,10 +116,14 @@
         description.value = props.event.description || "";
         allDay.value = props.event.all_day;
         startLocal.value = toDateTimeLocal(props.event.start);
-        endLocal.value = props.event.end ? toDateTimeLocal(props.event.end) : "";
+        endLocal.value = props.event.end
+          ? toDateTimeLocal(props.event.end)
+          : "";
         color.value = props.event.color || presets[0];
       } else {
-        const base = props.defaultStart ? new Date(props.defaultStart) : new Date();
+        const base = props.defaultStart
+          ? new Date(props.defaultStart)
+          : new Date();
         title.value = "";
         description.value = "";
         allDay.value = false;
@@ -115,7 +131,7 @@
         endLocal.value = "";
         color.value = presets[0];
       }
-    }
+    },
   );
 
   async function submit() {
@@ -148,20 +164,15 @@
     saving.value = true;
     try {
       if (isEdit.value) {
-        await $api(`/calendar/user/update-event/${props.event.id}/`, {
-          method: "PATCH",
-          body: payload,
-        });
+        await updateEvent(props.event.id, payload);
       } else {
-        await $api("/calendar/user/create-event/", {
-          method: "POST",
-          body: payload,
-        });
+        await createEvent(payload);
       }
+      toast.success(isEdit.value ? "Event updated." : "Event created.");
       emit("saved");
       open.value = false;
     } catch (err) {
-      error.value = "Couldn't save the event.";
+      error.value = err?.data?.detail || "Couldn't save the event.";
       console.error("Error saving event:", err);
     } finally {
       saving.value = false;
@@ -172,13 +183,12 @@
     if (deleting.value) return;
     deleting.value = true;
     try {
-      await $api(`/calendar/user/delete-event/${props.event.id}/`, {
-        method: "DELETE",
-      });
+      await deleteEvent(props.event.id);
+      toast.success("Event deleted.");
       emit("deleted");
       open.value = false;
     } catch (err) {
-      error.value = "Couldn't delete the event.";
+      error.value = err?.data?.detail || "Couldn't delete the event.";
       console.error("Error deleting event:", err);
     } finally {
       deleting.value = false;

--- a/gui/components/ui/ToastContainer.vue
+++ b/gui/components/ui/ToastContainer.vue
@@ -1,0 +1,64 @@
+<template>
+  <Teleport to="body">
+    <div
+      class="pointer-events-none fixed inset-x-0 bottom-0 z-[100] flex flex-col items-center gap-2 p-4 sm:items-end">
+      <TransitionGroup name="toast">
+        <div
+          v-for="toast in toasts"
+          :key="toast.id"
+          class="pointer-events-auto flex w-full max-w-sm items-start gap-3 rounded-xl border px-4 py-3 text-sm shadow-card"
+          :class="styles[toast.type].box"
+          role="status">
+          <Icon
+            :name="styles[toast.type].icon"
+            class="mt-0.5 size-[18px] shrink-0"
+            :class="styles[toast.type].iconColor" />
+          <p class="min-w-0 flex-1">{{ toast.message }}</p>
+          <button
+            class="-mr-1 shrink-0 rounded-md p-0.5 text-muted-foreground transition-colors hover:text-foreground"
+            aria-label="Dismiss"
+            @click="dismiss(toast.id)">
+            <Icon name="lucide:x" class="size-4" />
+          </button>
+        </div>
+      </TransitionGroup>
+    </div>
+  </Teleport>
+</template>
+
+<script setup>
+  const { toasts, dismiss } = useToast();
+
+  const styles = {
+    success: {
+      box: "border-accent/25 bg-card text-foreground",
+      icon: "lucide:circle-check",
+      iconColor: "text-accent",
+    },
+    error: {
+      box: "border-danger/25 bg-card text-foreground",
+      icon: "lucide:circle-alert",
+      iconColor: "text-danger",
+    },
+    info: {
+      box: "border-primary/25 bg-card text-foreground",
+      icon: "lucide:info",
+      iconColor: "text-primary",
+    },
+  };
+</script>
+
+<style scoped>
+  .toast-enter-active,
+  .toast-leave-active {
+    transition: all 0.22s ease;
+  }
+  .toast-enter-from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  .toast-leave-to {
+    opacity: 0;
+    transform: translateX(12px);
+  }
+</style>

--- a/gui/composables/useCalendar.js
+++ b/gui/composables/useCalendar.js
@@ -1,0 +1,24 @@
+// Wraps the calendar / event API calls. Must be called from a setup context.
+export function useCalendar() {
+  const { $api } = useNuxtApp();
+
+  return {
+    getCalendar: (start, end, includeDeleted = false) =>
+      $api("/calendar/user/get-calendar/", {
+        method: "GET",
+        query: { start, end, include_deleted: includeDeleted },
+      }),
+
+    createEvent: (payload) =>
+      $api("/calendar/user/create-event/", { method: "POST", body: payload }),
+
+    updateEvent: (id, payload) =>
+      $api(`/calendar/user/update-event/${id}/`, {
+        method: "PATCH",
+        body: payload,
+      }),
+
+    deleteEvent: (id) =>
+      $api(`/calendar/user/delete-event/${id}/`, { method: "DELETE" }),
+  };
+}

--- a/gui/composables/useDashboard.js
+++ b/gui/composables/useDashboard.js
@@ -1,0 +1,18 @@
+// Wraps the dashboard aggregation API calls. Must be called from a setup context.
+export function useDashboard() {
+  const { $api } = useNuxtApp();
+
+  return {
+    getSummary: (includeDeleted = false) =>
+      $api("/dashboard/user/get-summary/", {
+        method: "GET",
+        query: { include_deleted: includeDeleted },
+      }),
+
+    getTimeSeries: (start, end, bucket, includeDeleted = false) =>
+      $api("/dashboard/user/get-time-series/", {
+        method: "GET",
+        query: { start, end, bucket, include_deleted: includeDeleted },
+      }),
+  };
+}

--- a/gui/composables/useTasks.js
+++ b/gui/composables/useTasks.js
@@ -1,0 +1,64 @@
+// Wraps the task / subtask / time-entry API calls so pages don't repeat the
+// endpoint paths and request shapes. Must be called from a setup context.
+export function useTasks() {
+  const { $api } = useNuxtApp();
+
+  return {
+    fetchTasks: () =>
+      $api("/ticktask/user/get-tasks-and-subtasks/", { method: "GET" }),
+
+    createTask: (name) =>
+      $api("/ticktask/user/create-task/", { method: "POST", body: { name } }),
+
+    createSubtask: (taskId, name, description) =>
+      $api("/ticktask/user/create-subtask/", {
+        method: "POST",
+        body: { task_id: taskId, name, description },
+      }),
+
+    deleteTask: (taskId) =>
+      $api("/ticktask/user/delete-task/", {
+        method: "POST",
+        body: { task_id: taskId },
+      }),
+
+    deleteSubtask: (subtaskId) =>
+      $api("/ticktask/user/delete-subtask/", {
+        method: "POST",
+        body: { subtask_id: subtaskId },
+      }),
+
+    restoreTask: (taskId) =>
+      $api("/ticktask/user/restore-task/", {
+        method: "POST",
+        body: { task_id: taskId },
+      }),
+
+    restoreSubtask: (subtaskId) =>
+      $api("/ticktask/user/restore-subtask/", {
+        method: "POST",
+        body: { subtask_id: subtaskId },
+      }),
+
+    clockIn: (subtaskId) =>
+      $api("/ticktask/user/clock-in/", {
+        method: "POST",
+        body: { subtask_id: subtaskId },
+      }),
+
+    clockOut: (entityId) =>
+      $api("/ticktask/user/clock-out/", {
+        method: "POST",
+        body: { entity_id: entityId },
+      }),
+
+    getClockedIn: () =>
+      $api("/ticktask/user/get-clocked-in-time-entry/", { method: "GET" }),
+
+    getTimeEntries: (subtaskId, lastHours) =>
+      $api("/ticktask/user/get-time-entries/", {
+        method: "POST",
+        body: { subtask_id: subtaskId, last_hours: lastHours },
+      }),
+  };
+}

--- a/gui/composables/useToast.js
+++ b/gui/composables/useToast.js
@@ -1,0 +1,28 @@
+// A tiny global toast/notification store. Module-level state makes it a
+// singleton shared across the app, so any component can push a notification.
+import { reactive } from "vue";
+
+const toasts = reactive([]);
+let nextId = 0;
+
+function show(message, type, timeout) {
+  const id = ++nextId;
+  toasts.push({ id, message, type });
+  if (timeout) setTimeout(() => dismiss(id), timeout);
+  return id;
+}
+
+function dismiss(id) {
+  const index = toasts.findIndex((t) => t.id === id);
+  if (index !== -1) toasts.splice(index, 1);
+}
+
+export function useToast() {
+  return {
+    toasts,
+    dismiss,
+    success: (message, timeout = 4000) => show(message, "success", timeout),
+    error: (message, timeout = 6000) => show(message, "error", timeout),
+    info: (message, timeout = 4000) => show(message, "info", timeout),
+  };
+}

--- a/gui/layouts/defaultlogged.vue
+++ b/gui/layouts/defaultlogged.vue
@@ -24,6 +24,8 @@
         <slot />
       </main>
     </div>
+
+    <UiToastContainer />
   </div>
 </template>
 

--- a/gui/pages/calendar.vue
+++ b/gui/pages/calendar.vue
@@ -3,7 +3,9 @@
     <div class="flex flex-wrap items-end justify-between gap-4">
       <div>
         <h1 class="text-2xl font-bold tracking-tight sm:text-3xl">Calendar</h1>
-        <p class="mt-1 text-muted-foreground">Your tracked time and scheduled events.</p>
+        <p class="mt-1 text-muted-foreground">
+          Your tracked time and scheduled events.
+        </p>
       </div>
       <div class="flex items-center gap-4">
         <label
@@ -14,7 +16,9 @@
             class="size-4 rounded border-border accent-primary" />
           Show deleted
         </label>
-        <UiButton icon="lucide:plus" @click="openCreate(new Date())">New event</UiButton>
+        <UiButton icon="lucide:plus" @click="openCreate(new Date())"
+          >New event</UiButton
+        >
       </div>
     </div>
 
@@ -22,11 +26,21 @@
       <!-- Toolbar -->
       <div class="mb-4 flex items-center justify-between gap-3">
         <div class="flex items-center gap-2">
-          <UiButton variant="outline" size="icon" icon="lucide:chevron-left" @click="prevMonth" />
-          <UiButton variant="outline" size="icon" icon="lucide:chevron-right" @click="nextMonth" />
+          <UiButton
+            variant="outline"
+            size="icon"
+            icon="lucide:chevron-left"
+            @click="prevMonth" />
+          <UiButton
+            variant="outline"
+            size="icon"
+            icon="lucide:chevron-right"
+            @click="nextMonth" />
           <UiButton variant="ghost" size="sm" @click="goToday">Today</UiButton>
         </div>
-        <h2 class="text-lg font-semibold capitalize">{{ monthLabel(cursor) }}</h2>
+        <h2 class="text-lg font-semibold capitalize">
+          {{ monthLabel(cursor) }}
+        </h2>
         <div class="w-[88px]"></div>
       </div>
 
@@ -45,7 +59,9 @@
         <div
           v-if="loading"
           class="absolute inset-0 z-20 flex items-center justify-center rounded-xl bg-card/60 backdrop-blur-sm">
-          <Icon name="lucide:loader-circle" class="size-6 animate-spin text-muted-foreground" />
+          <Icon
+            name="lucide:loader-circle"
+            class="size-6 animate-spin text-muted-foreground" />
         </div>
 
         <div
@@ -122,7 +138,8 @@
     layout: "defaultlogged",
   });
 
-  const { $api } = useNuxtApp();
+  const { getCalendar } = useCalendar();
+  const toast = useToast();
 
   const weekdays = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
 
@@ -189,21 +206,19 @@
         last.getDate(),
         23,
         59,
-        59
+        59,
       );
 
-      const res = await $api("/calendar/user/get-calendar/", {
-        method: "GET",
-        query: {
-          start: first.toISOString(),
-          end: rangeEnd.toISOString(),
-          include_deleted: includeDeleted.value,
-        },
-      });
+      const res = await getCalendar(
+        first.toISOString(),
+        rangeEnd.toISOString(),
+        includeDeleted.value,
+      );
       events.value = res.events;
       timeEntries.value = res.time_entries;
     } catch (err) {
       console.error("Error loading calendar:", err);
+      toast.error("Couldn't load the calendar.");
     } finally {
       loading.value = false;
     }

--- a/gui/pages/dashboard.vue
+++ b/gui/pages/dashboard.vue
@@ -17,10 +17,6 @@
       </label>
     </div>
 
-    <UiAlert v-if="error" variant="danger">
-      Couldn't load your dashboard. Please try again.
-    </UiAlert>
-
     <!-- Stat cards -->
     <div class="grid grid-cols-2 gap-4 lg:grid-cols-4">
       <DashboardStatCard
@@ -101,14 +97,16 @@
     layout: "defaultlogged",
   });
 
-  const { $api } = useNuxtApp();
+  const { getSummary, getTimeSeries } = useDashboard();
+  const { restoreTask: apiRestoreTask, restoreSubtask: apiRestoreSubtask } =
+    useTasks();
+  const toast = useToast();
 
   const bucket = ref("day");
   const includeDeleted = ref(false);
   const summary = ref(null);
   const series = ref(null);
   const seriesLoading = ref(false);
-  const error = ref(false);
 
   const statCards = computed(() => {
     const s = summary.value;
@@ -150,13 +148,10 @@
 
   async function loadSummary() {
     try {
-      summary.value = await $api("/dashboard/user/get-summary/", {
-        method: "GET",
-        query: { include_deleted: includeDeleted.value },
-      });
+      summary.value = await getSummary(includeDeleted.value);
     } catch (err) {
       console.error("Error loading dashboard summary:", err);
-      error.value = true;
+      toast.error("Couldn't load the dashboard summary.");
     }
   }
 
@@ -164,37 +159,40 @@
     seriesLoading.value = true;
     try {
       const { start, end } = rangeForBucket(bucket.value);
-      series.value = await $api("/dashboard/user/get-time-series/", {
-        method: "GET",
-        query: {
-          start: start.toISOString(),
-          end: end.toISOString(),
-          bucket: bucket.value,
-          include_deleted: includeDeleted.value,
-        },
-      });
+      series.value = await getTimeSeries(
+        start.toISOString(),
+        end.toISOString(),
+        bucket.value,
+        includeDeleted.value,
+      );
     } catch (err) {
       console.error("Error loading dashboard series:", err);
-      error.value = true;
+      toast.error("Couldn't load the dashboard chart.");
     } finally {
       seriesLoading.value = false;
     }
   }
 
   async function restoreTask(taskId) {
-    await $api("/ticktask/user/restore-task/", {
-      method: "POST",
-      body: { task_id: taskId },
-    });
-    await Promise.all([loadSummary(), loadSeries()]);
+    try {
+      await apiRestoreTask(taskId);
+      toast.success("Task restored.");
+      await Promise.all([loadSummary(), loadSeries()]);
+    } catch (err) {
+      console.error("Error restoring task:", err);
+      toast.error("Couldn't restore the task.");
+    }
   }
 
   async function restoreSubtask(subtaskId) {
-    await $api("/ticktask/user/restore-subtask/", {
-      method: "POST",
-      body: { subtask_id: subtaskId },
-    });
-    await Promise.all([loadSummary(), loadSeries()]);
+    try {
+      await apiRestoreSubtask(subtaskId);
+      toast.success("Subtask restored.");
+      await Promise.all([loadSummary(), loadSeries()]);
+    } catch (err) {
+      console.error("Error restoring subtask:", err);
+      toast.error("Couldn't restore the subtask.");
+    }
   }
 
   onMounted(loadSummary);

--- a/gui/pages/time-tracking.vue
+++ b/gui/pages/time-tracking.vue
@@ -246,7 +246,16 @@
     layout: "defaultlogged",
   });
 
-  const { $api } = useNuxtApp();
+  const {
+    fetchTasks,
+    getClockedIn,
+    clockIn: apiClockIn,
+    clockOut: apiClockOut,
+    getTimeEntries,
+    deleteTask: apiDeleteTask,
+    deleteSubtask: apiDeleteSubtask,
+  } = useTasks();
+  const toast = useToast();
 
   const tasks = ref([]);
   const loadingTasks = ref(false);
@@ -290,13 +299,9 @@
   onMounted(async () => {
     loadingTasks.value = true;
     try {
-      tasks.value = await $api("/ticktask/user/get-tasks-and-subtasks/", {
-        method: "GET",
-      });
+      tasks.value = await fetchTasks();
 
-      const active = await $api("/ticktask/user/get-clocked-in-time-entry/", {
-        method: "GET",
-      });
+      const active = await getClockedIn();
       if (active) {
         const subtask = active.subtasks[0];
         const entry = subtask.time_entries[0];
@@ -314,6 +319,7 @@
       }
     } catch (error) {
       console.error("Error fetching tasks:", error);
+      toast.error("Couldn't load your tasks.");
     } finally {
       loadingTasks.value = false;
     }
@@ -347,20 +353,15 @@
 
   async function clockIn() {
     try {
-      const existing = await $api("/ticktask/user/get-clocked-in-time-entry/", {
-        method: "GET",
-      });
+      const existing = await getClockedIn();
       if (existing) {
-        alert(
-          "You already have an active task. Please close it before starting a new one.",
+        toast.info(
+          "You already have an active task. Clock it out before starting a new one.",
         );
         return;
       }
 
-      const response = await $api("/ticktask/user/clock-in/", {
-        method: "POST",
-        body: { subtask_id: selectedSubtask.value.id },
-      });
+      const response = await apiClockIn(selectedSubtask.value.id);
 
       isClockedIn.value = true;
       clockInTime.value = new Date(response.clock_in);
@@ -371,36 +372,23 @@
       fetchRecentTimeEntries(activeSubTask.value.id);
     } catch (err) {
       console.error("Error during clock in:", err);
+      toast.error(err?.data?.detail || "Couldn't clock in.");
     }
   }
 
   async function clockOut() {
     try {
-      await $api("/ticktask/user/clock-out/", {
-        method: "POST",
-        body: { entity_id: activeTimeEntryId.value },
-      });
-
-      isClockedIn.value = false;
-      if (clockInterval) clearInterval(clockInterval);
-
-      clockInTime.value = null;
-      clockInDuration.value = "00:00:00";
-      activeTimeEntryId.value = null;
-      activeTask.value = null;
-      activeSubTask.value = null;
-      recentTimeEntries.value = [];
+      await apiClockOut(activeTimeEntryId.value);
+      resetTracker();
     } catch (err) {
       console.error("Error during clock out:", err);
+      toast.error("Couldn't clock out.");
     }
   }
 
   async function fetchRecentTimeEntries(subtaskId) {
     try {
-      recentTimeEntries.value = await $api("/ticktask/user/get-time-entries/", {
-        method: "POST",
-        body: { subtask_id: subtaskId, last_hours: 24 },
-      });
+      recentTimeEntries.value = await getTimeEntries(subtaskId, 24);
     } catch (err) {
       console.error("Error fetching recent time entries:", err);
       recentTimeEntries.value = [];
@@ -421,6 +409,7 @@
   function handleTaskCreated(task) {
     tasks.value.push({ ...task, subtasks: task.subtasks ?? [] });
     expanded.value = [...expanded.value, task.id];
+    toast.success(`Task "${task.name}" created.`);
   }
 
   function openAddSubTaskDialog(task) {
@@ -437,6 +426,7 @@
         ...newSubtask,
         time_entries: newSubtask.time_entries ?? [],
       });
+    toast.success(`Subtask "${newSubtask.name}" created.`);
   }
 
   function resetTracker() {
@@ -466,32 +456,29 @@
     try {
       const { kind, task, subtask } = pendingDelete.value;
       if (kind === "task") {
-        await $api("/ticktask/user/delete-task/", {
-          method: "POST",
-          body: { task_id: task.id },
-        });
+        await apiDeleteTask(task.id);
         tasks.value = tasks.value.filter((t) => t.id !== task.id);
         if (selectedTask.value?.id === task.id) {
           selectedTask.value = null;
           selectedSubtask.value = null;
         }
         if (activeTask.value?.id === task.id) resetTracker();
+        toast.success(`Task "${task.name}" deleted.`);
       } else {
-        await $api("/ticktask/user/delete-subtask/", {
-          method: "POST",
-          body: { subtask_id: subtask.id },
-        });
+        await apiDeleteSubtask(subtask.id);
         const parent = tasks.value.find((t) => t.id === task.id);
         if (parent)
           parent.subtasks = parent.subtasks.filter((s) => s.id !== subtask.id);
-        if (selectedSubtask.value?.id === subtask.id) selectedSubtask.value = null;
+        if (selectedSubtask.value?.id === subtask.id)
+          selectedSubtask.value = null;
         if (activeSubTask.value?.id === subtask.id) resetTracker();
+        toast.success(`Subtask "${subtask.name}" deleted.`);
       }
       confirmOpen.value = false;
       pendingDelete.value = null;
     } catch (err) {
       console.error("Error deleting:", err);
-      alert(err?.data?.detail || "Couldn't delete. Please try again.");
+      toast.error(err?.data?.detail || "Couldn't delete. Please try again.");
     } finally {
       confirmLoading.value = false;
     }

--- a/ticktask/server/routes/auth.py
+++ b/ticktask/server/routes/auth.py
@@ -22,7 +22,6 @@ def login(request, data: LoginSchema):
     """
     This endpoint checks and performs the login access into the app
     """
-    print(f"User: {data.username} and password: {data.password}")
     user = authenticate(username=data.username, password=data.password)
     if user:
         refresh = RefreshToken.for_user(user)
@@ -30,10 +29,6 @@ def login(request, data: LoginSchema):
         # Save login log
         user_ip = request.META.get("REMOTE_ADDR", "")
         user_agent = request.META.get("HTTP_USER_AGENT", "")
-        print(
-            f"User {user.username} logged in from IP: {user_ip}, User-Agent: {user_agent}"
-        )
-
         UserLoginRecord.objects.create(  # pylint: disable=no-member
             user=user, ip_address=user_ip, user_agent=user_agent
         )

--- a/ticktask/server/routes/tasks.py
+++ b/ticktask/server/routes/tasks.py
@@ -49,8 +49,6 @@ def get_user_tasks(request):
     """
     Returns the tasks and subtasks associated to each user.
     """
-    if not request.auth:
-        return {"error": "No autorizado"}, 401
     active_subtasks = SubTask.objects.filter(deleted_at__isnull=True)  # pylint: disable=no-member
     tasks = (
         Task.objects.filter(user=request.auth, deleted_at__isnull=True)  # pylint: disable=no-member
@@ -70,9 +68,6 @@ def create_task(request, data: TaskCreationSchema):
     """
     Creates a new task for the authenticated user.
     """
-    if not request.auth:
-        return {"error": "No autorizado"}, 401
-
     name = data.name.strip()
     if not name:
         raise HttpError(422, "El nombre de la tarea no puede estar vacío.")
@@ -106,9 +101,6 @@ def create_subtask(request, data: SubTaskCreationSchema):
     """
     Creates a new subtask for the authenticated user.
     """
-    if not request.auth:
-        return {"error": "No autorizado"}, 401
-
     try:
         task = Task.objects.get(id=data.task_id, user=request.auth)  # pylint: disable=no-member
     except Task.DoesNotExist:  # pylint: disable=no-member
@@ -149,9 +141,6 @@ def delete_task(request, data: TaskIdSchema):
     its tracked time is kept (and still visible on the dashboard/calendar).
     Any open time entry under it is closed.
     """
-    if not request.auth:
-        return {"error": "No autorizado"}, 401
-
     try:
         task = Task.objects.get(id=data.task_id, user=request.auth)  # pylint: disable=no-member
     except Task.DoesNotExist:  # pylint: disable=no-member
@@ -180,9 +169,6 @@ def restore_task(request, data: TaskIdSchema):
     tracking. The unique name guarantees there is never a conflicting active
     task, so this cannot create a duplicate.
     """
-    if not request.auth:
-        return {"error": "No autorizado"}, 401
-
     try:
         task = Task.objects.get(id=data.task_id, user=request.auth)  # pylint: disable=no-member
     except Task.DoesNotExist:  # pylint: disable=no-member
@@ -205,9 +191,6 @@ def delete_subtask(request, data: SubTaskIdSchema):
     """
     Soft-deletes one of the user's subtasks (closing any open time entry on it).
     """
-    if not request.auth:
-        return {"error": "No autorizado"}, 401
-
     try:
         subtask = SubTask.objects.select_related("task").get(  # pylint: disable=no-member
             id=data.subtask_id, task__user=request.auth
@@ -236,9 +219,6 @@ def restore_subtask(request, data: SubTaskIdSchema):
     """
     Restores a previously soft-deleted subtask.
     """
-    if not request.auth:
-        return {"error": "No autorizado"}, 401
-
     try:
         subtask = SubTask.objects.select_related("task").get(  # pylint: disable=no-member
             id=data.subtask_id, task__user=request.auth
@@ -263,9 +243,6 @@ def clock_in(request, data: ClockInSchema):
     """
     Registers a new time entry to the corresponding subtask.
     """
-    if not request.auth:
-        return {"error": "No autorizado"}, 401
-
     try:
         subtask = SubTask.objects.select_related("task").get(id=data.subtask_id)  # pylint: disable=no-member
     except SubTask.DoesNotExist:  # pylint: disable=no-member
@@ -290,10 +267,6 @@ def clock_out(request, data: ClockOutSchema):
     """
     Updates the given TimeEntry with clock_out.
     """
-    print("Clocking out")
-    if not request.auth:
-        return {"error": "No autorizado"}, 401
-
     try:
         entry = TimeEntry.objects.select_related("subtask__task").get(  # pylint: disable=no-member
             id=data.entity_id, clock_out__isnull=True
@@ -319,8 +292,6 @@ def get_user_clocked_in_activity(request):
     """
     Returns the `Task` where the user is clocked in if exists.
     """
-    if not request.auth:
-        return {"error": "No autorizado"}, 401
     time_entry = (
         TimeEntry.objects.select_related("subtask__task")  # pylint: disable=no-member
         .filter(
@@ -368,8 +339,6 @@ def get_history_time_entries(request, data: TimeEntryHistoryRequestSchema):
     """
     Returns the `TimeEntry`s associated with a specific subtask.
     """
-    if not request.auth:
-        return {"error": "No autorizado"}, 401
     cutoff = timezone.now() - timedelta(hours=data.last_hours)
     time_entries = TimeEntry.objects.filter(  # pylint: disable=no-member
         subtask_id=data.subtask_id, clock_in__gte=cutoff


### PR DESCRIPTION
## Cleanup & polish: toasts, API composables, backend hygiene

Cross-cutting quality work from the roadmap — no new features. Addresses the backend-cleanup items and three of the polish items (toasts, consistent error feedback, API composables).

### Backend cleanup

- Removed leftover `print()` debug statements — including one in `login` that **logged the username and password in plain text**.
- Dropped the unreachable `return {...}, 401` guards in `tasks.py` (under `auth=JWTAuth()` the auth layer short-circuits before the handler runs), aligning the older routes with the calendar/dashboard style.

### Toasts

- New tiny global notification store (`useToast`) + `UiToastContainer`, mounted once in the logged-in layout.
- Replaced the `alert()` calls in time tracking with toasts and added success/error toasts across the app: create/delete/restore tasks and subtasks, clock-in/out, and calendar events.

### Consistent error feedback

- Errors now surface uniformly through `toast.error` instead of bare `console.error` (and the dashboard's one-off error banner has been removed). Loading and empty states already existed per page.

### API composables

- Extracted all `$api` calls into composables — `useTasks`, `useCalendar`, `useDashboard` — so pages and dialogs no longer hard-code endpoint paths or request shapes.
- Refactored `time-tracking`, `calendar` and `dashboard` pages plus the `AddTaskDialog`, `AddSubTaskDialog` and `EventDialog` components to use them. The only remaining reference to `$api` is the plugin that provides it.