### PR TITLE
History page

### DIFF
--- a/gui/composables/useTasks.js
+++ b/gui/composables/useTasks.js
@@ -60,5 +60,11 @@ export function useTasks() {
         method: "POST",
         body: { subtask_id: subtaskId, last_hours: lastHours },
       }),
+
+    getTimeHistory: (start, end, includeDeleted = false) =>
+      $api("/ticktask/user/get-time-history/", {
+        method: "GET",
+        query: { start, end, include_deleted: includeDeleted },
+      }),
   };
 }

--- a/gui/pages/time-history.vue
+++ b/gui/pages/time-history.vue
@@ -1,34 +1,217 @@
 <template>
-  <div class="mx-auto max-w-6xl space-y-6">
-    <div>
-      <h1 class="text-2xl font-bold tracking-tight sm:text-3xl">History</h1>
-      <p class="mt-1 text-muted-foreground">
-        Browse and review your past time entries.
-      </p>
+  <div class="mx-auto max-w-4xl space-y-6">
+    <div class="flex flex-wrap items-start justify-between gap-4">
+      <div>
+        <h1 class="text-2xl font-bold tracking-tight sm:text-3xl">History</h1>
+        <p class="mt-1 text-muted-foreground">
+          Browse and review your past time entries.
+        </p>
+      </div>
+      <label
+        class="flex cursor-pointer select-none items-center gap-2 text-sm text-muted-foreground">
+        <input
+          v-model="includeDeleted"
+          type="checkbox"
+          class="size-4 rounded border-border accent-primary" />
+        Show deleted
+      </label>
     </div>
 
+    <!-- Controls -->
     <UiCard>
-      <div class="flex flex-col items-center gap-3 py-16 text-center">
+      <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div class="inline-flex rounded-xl border border-border p-0.5">
+          <button
+            v-for="option in RANGES"
+            :key="option.value"
+            class="rounded-lg px-3 py-1 text-sm font-medium transition-colors"
+            :class="
+              range === option.value
+                ? 'bg-primary text-primary-foreground shadow-soft'
+                : 'text-muted-foreground hover:text-foreground'
+            "
+            @click="range = option.value">
+            {{ option.label }}
+          </button>
+        </div>
+        <div class="sm:w-64">
+          <UiInput
+            v-model="search"
+            icon="lucide:search"
+            placeholder="Search by task or subtask" />
+        </div>
+      </div>
+      <p class="mt-3 text-sm text-muted-foreground">
+        {{ totalEntries }} {{ totalEntries === 1 ? "entry" : "entries" }} ·
+        {{ formatDuration(totalMs) }} tracked
+      </p>
+    </UiCard>
+
+    <!-- Loading -->
+    <UiCard v-if="loading">
+      <div class="flex items-center justify-center py-12 text-muted-foreground">
+        <Icon name="lucide:loader-circle" class="size-6 animate-spin" />
+      </div>
+    </UiCard>
+
+    <!-- Empty -->
+    <UiCard v-else-if="!groups.length">
+      <div class="flex flex-col items-center gap-3 py-12 text-center">
         <div
-          class="flex size-14 items-center justify-center rounded-2xl bg-muted text-muted-foreground">
-          <Icon name="lucide:history" class="size-7" />
+          class="flex size-12 items-center justify-center rounded-2xl bg-muted text-muted-foreground">
+          <Icon name="lucide:history" class="size-6" />
         </div>
         <div>
-          <p class="font-semibold">Coming soon</p>
-          <p class="mt-1 max-w-sm text-sm text-muted-foreground">
-            A searchable history of every time entry, grouped by task and date,
-            is on the way.
+          <p class="font-medium">No time entries</p>
+          <p class="text-sm text-muted-foreground">
+            {{
+              search
+                ? "Nothing matches your search in this range."
+                : "Nothing tracked in this range yet."
+            }}
           </p>
         </div>
       </div>
     </UiCard>
+
+    <!-- Grouped by day -->
+    <div v-else class="space-y-5">
+      <div v-for="group in groups" :key="group.key">
+        <div class="mb-2 flex items-baseline justify-between px-1">
+          <h2 class="text-sm font-semibold">{{ formatDay(group.date) }}</h2>
+          <span class="text-xs font-medium tabular-nums text-muted-foreground">
+            {{ formatDuration(group.totalMs) }}
+          </span>
+        </div>
+        <UiCard :padded="false">
+          <ul class="divide-y divide-border">
+            <li
+              v-for="entry in group.entries"
+              :key="entry.id"
+              class="flex items-center gap-3 px-4 py-3">
+              <span class="w-24 shrink-0 text-sm tabular-nums text-muted-foreground">
+                {{ formatClock(entry.clock_in) }} –
+                {{ entry.clock_out ? formatClock(entry.clock_out) : "now" }}
+              </span>
+              <span class="min-w-0 flex-1 truncate text-sm">
+                <span
+                  class="font-medium"
+                  :class="{ 'text-muted-foreground line-through': entry.deleted }">
+                  {{ entry.task_name }}
+                </span>
+                <span class="text-muted-foreground">› {{ entry.subtask_name }}</span>
+                <span
+                  v-if="entry.deleted"
+                  class="ml-1.5 rounded-full bg-muted px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+                  deleted
+                </span>
+              </span>
+              <span
+                class="shrink-0 text-sm font-semibold tabular-nums"
+                :class="{ 'text-muted-foreground': !entry.clock_out }">
+                {{ formatDuration(durationMs(entry)) }}
+              </span>
+            </li>
+          </ul>
+        </UiCard>
+      </div>
+    </div>
   </div>
 </template>
 
 <script setup>
+  import { ref, computed, watch } from "vue";
+
   definePageMeta({
     middleware: "auth",
     requiresAuth: true,
     layout: "defaultlogged",
   });
+
+  const { getTimeHistory } = useTasks();
+  const toast = useToast();
+
+  const RANGES = [
+    { value: "7", label: "7 days", days: 7 },
+    { value: "30", label: "30 days", days: 30 },
+    { value: "90", label: "90 days", days: 90 },
+  ];
+
+  const range = ref("30");
+  const search = ref("");
+  const includeDeleted = ref(false);
+  const entries = ref([]);
+  const loading = ref(false);
+
+  function durationMs(entry) {
+    const end = entry.clock_out ? new Date(entry.clock_out) : new Date();
+    return Math.max(0, end - new Date(entry.clock_in));
+  }
+
+  function formatDay(date) {
+    return date.toLocaleDateString([], {
+      weekday: "short",
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+    });
+  }
+
+  const filtered = computed(() => {
+    const query = search.value.trim().toLowerCase();
+    if (!query) return entries.value;
+    return entries.value.filter(
+      (entry) =>
+        entry.task_name.toLowerCase().includes(query) ||
+        entry.subtask_name.toLowerCase().includes(query),
+    );
+  });
+
+  const groups = computed(() => {
+    // Entries arrive newest-first, so days are first seen in descending order.
+    const map = new Map();
+    for (const entry of filtered.value) {
+      const key = dayKey(new Date(entry.clock_in));
+      if (!map.has(key)) {
+        map.set(key, {
+          key,
+          date: new Date(entry.clock_in),
+          entries: [],
+          totalMs: 0,
+        });
+      }
+      const group = map.get(key);
+      group.entries.push(entry);
+      group.totalMs += durationMs(entry);
+    }
+    return Array.from(map.values());
+  });
+
+  const totalEntries = computed(() => filtered.value.length);
+  const totalMs = computed(() =>
+    filtered.value.reduce((sum, entry) => sum + durationMs(entry), 0),
+  );
+
+  async function load() {
+    loading.value = true;
+    try {
+      const option = RANGES.find((r) => r.value === range.value);
+      const end = new Date();
+      const start = new Date(end);
+      start.setDate(start.getDate() - option.days);
+      start.setHours(0, 0, 0, 0);
+      entries.value = await getTimeHistory(
+        start.toISOString(),
+        end.toISOString(),
+        includeDeleted.value,
+      );
+    } catch (err) {
+      console.error("Error loading history:", err);
+      toast.error("Couldn't load your history.");
+    } finally {
+      loading.value = false;
+    }
+  }
+
+  watch([range, includeDeleted], load, { immediate: true });
 </script>

--- a/ticktask/server/routes/tasks.py
+++ b/ticktask/server/routes/tasks.py
@@ -4,7 +4,7 @@ tasks and subtasks information.
 """
 
 import os
-from datetime import timedelta
+from datetime import datetime, timedelta
 
 import django
 from ninja import Router
@@ -24,6 +24,7 @@ from ticktask.server.schemas.time_entry_schema import (
     ClockOutSchema,
     TimeEntrySchema,
     TimeEntryHistoryRequestSchema,
+    HistoryEntrySchema,
 )
 
 try:
@@ -344,3 +345,48 @@ def get_history_time_entries(request, data: TimeEntryHistoryRequestSchema):
         subtask_id=data.subtask_id, clock_in__gte=cutoff
     ).order_by("-clock_in")
     return time_entries
+
+
+@ticktask_router.get(
+    "/user/get-time-history/",
+    response=list[HistoryEntrySchema],
+    tags=["Ticktask"],
+    auth=JWTAuth(),
+)
+def get_time_history(
+    request, start: datetime, end: datetime, include_deleted: bool = False
+):
+    """
+    Returns the user's time entries whose ``clock_in`` falls within
+    ``[start, end]``, flattened with their subtask and task names and ordered
+    newest first. Entries of soft-deleted subtasks/tasks are excluded unless
+    ``include_deleted`` is set, in which case they are flagged with
+    ``deleted: true``.
+    """
+    entries = (
+        TimeEntry.objects.select_related("subtask__task")  # pylint: disable=no-member
+        .filter(
+            subtask__task__user=request.auth,
+            clock_in__gte=start,
+            clock_in__lte=end,
+        )
+        .order_by("-clock_in")
+    )
+    if not include_deleted:
+        entries = entries.filter(
+            subtask__deleted_at__isnull=True, subtask__task__deleted_at__isnull=True
+        )
+
+    return [
+        {
+            "id": entry.id,
+            "clock_in": entry.clock_in,
+            "clock_out": entry.clock_out,
+            "subtask_id": entry.subtask_id,
+            "subtask_name": entry.subtask.name,
+            "task_id": entry.subtask.task_id,
+            "task_name": entry.subtask.task.name,
+            "deleted": entry.subtask.is_deleted or entry.subtask.task.is_deleted,
+        }
+        for entry in entries
+    ]

--- a/ticktask/server/schemas/time_entry_schema.py
+++ b/ticktask/server/schemas/time_entry_schema.py
@@ -41,3 +41,19 @@ class TimeEntryHistoryRequestSchema(Schema):
 
     subtask_id: int
     last_hours: int
+
+
+class HistoryEntrySchema(Schema):
+    """
+    A time entry as shown on the history page: flattened with the names of its
+    owning subtask and task, and whether either of them is soft-deleted.
+    """
+
+    id: int
+    clock_in: datetime
+    clock_out: datetime | None
+    subtask_id: int
+    subtask_name: str
+    task_id: int
+    task_name: str
+    deleted: bool = False

--- a/ticktask/tests/test_history.py
+++ b/ticktask/tests/test_history.py
@@ -1,0 +1,155 @@
+"""
+Tests for the time-entry history endpoint used by the history page.
+"""
+
+from datetime import datetime, timezone
+
+import pytest
+from django.test import Client
+from django.contrib.auth.models import User
+from ninja_jwt.tokens import RefreshToken
+
+from ticktask.models import Task, SubTask, TimeEntry
+
+BASE = "/api/ticktask/user"
+
+
+def make_user(username: str = "alice") -> User:
+    """Creates a user that owns the entries under test."""
+    return User.objects.create_user(username=username, password="pw")
+
+
+def auth_client(user: User) -> Client:
+    """Returns a Django test client authenticated as ``user`` via JWT."""
+    token = str(RefreshToken.for_user(user).access_token)
+    return Client(HTTP_AUTHORIZATION=f"Bearer {token}")
+
+
+def make_subtask(user: User, task_name: str, subtask_name: str) -> SubTask:
+    """Creates a task + subtask owned by ``user``."""
+    task, _ = Task.objects.get_or_create(user=user, name=task_name)  # pylint: disable=no-member
+    return SubTask.objects.create(  # pylint: disable=no-member
+        task=task, name=subtask_name, description="d"
+    )
+
+
+def make_entry(subtask: SubTask, clock_in: datetime, clock_out) -> TimeEntry:
+    """Creates a time entry with explicit timestamps (clock_in is auto_now_add)."""
+    entry = TimeEntry.objects.create(subtask=subtask)  # pylint: disable=no-member
+    TimeEntry.objects.filter(id=entry.id).update(  # pylint: disable=no-member
+        clock_in=clock_in, clock_out=clock_out
+    )
+    return entry
+
+
+def history(client: Client, start: datetime, end: datetime, include_deleted=None):
+    params = {"start": start.isoformat(), "end": end.isoformat()}
+    if include_deleted is not None:
+        params["include_deleted"] = include_deleted
+    return client.get(f"{BASE}/get-time-history/", params)
+
+
+RANGE = (
+    datetime(2026, 3, 1, 0, tzinfo=timezone.utc),
+    datetime(2026, 3, 4, 0, tzinfo=timezone.utc),
+)
+
+
+@pytest.mark.django_db
+def test_history_returns_flattened_entries_newest_first():
+    """Entries in range come back with task/subtask names, newest first."""
+    user = make_user()
+    subtask = make_subtask(user, "Proj", "Sub")
+    make_entry(
+        subtask,
+        datetime(2026, 3, 1, 9, tzinfo=timezone.utc),
+        datetime(2026, 3, 1, 10, tzinfo=timezone.utc),
+    )
+    make_entry(
+        subtask,
+        datetime(2026, 3, 3, 9, tzinfo=timezone.utc),
+        datetime(2026, 3, 3, 10, tzinfo=timezone.utc),
+    )
+
+    resp = history(auth_client(user), *RANGE)
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert [e["clock_in"][:10] for e in body] == ["2026-03-03", "2026-03-01"]
+    assert body[0]["task_name"] == "Proj"
+    assert body[0]["subtask_name"] == "Sub"
+    assert body[0]["deleted"] is False
+
+
+@pytest.mark.django_db
+def test_history_filters_by_range():
+    """Entries whose clock_in is outside the window are excluded."""
+    user = make_user()
+    subtask = make_subtask(user, "Proj", "Sub")
+    make_entry(
+        subtask,
+        datetime(2026, 3, 2, 9, tzinfo=timezone.utc),
+        datetime(2026, 3, 2, 10, tzinfo=timezone.utc),
+    )  # inside
+    make_entry(
+        subtask,
+        datetime(2026, 2, 1, 9, tzinfo=timezone.utc),
+        datetime(2026, 2, 1, 10, tzinfo=timezone.utc),
+    )  # before
+
+    body = history(auth_client(user), *RANGE).json()
+    assert len(body) == 1
+    assert body[0]["clock_in"][:10] == "2026-03-02"
+
+
+@pytest.mark.django_db
+def test_history_includes_open_entry():
+    """An entry still clocked in is returned with a null clock_out."""
+    user = make_user()
+    subtask = make_subtask(user, "Proj", "Sub")
+    make_entry(subtask, datetime(2026, 3, 2, 9, tzinfo=timezone.utc), None)
+
+    body = history(auth_client(user), *RANGE).json()
+    assert len(body) == 1
+    assert body[0]["clock_out"] is None
+
+
+@pytest.mark.django_db
+def test_history_scoped_to_user():
+    """Another user's entries are never returned."""
+    user = make_user("alice")
+    other = make_user("bob")
+    make_entry(
+        make_subtask(other, "Theirs", "Sub"),
+        datetime(2026, 3, 2, 9, tzinfo=timezone.utc),
+        datetime(2026, 3, 2, 10, tzinfo=timezone.utc),
+    )
+
+    body = history(auth_client(user), *RANGE).json()
+    assert body == []
+
+
+@pytest.mark.django_db
+def test_history_hides_deleted_by_default_and_can_include():
+    """Deleted subtasks/tasks are excluded unless include_deleted is set."""
+    user = make_user()
+    subtask = make_subtask(user, "Proj", "Sub")
+    make_entry(
+        subtask,
+        datetime(2026, 3, 2, 9, tzinfo=timezone.utc),
+        datetime(2026, 3, 2, 10, tzinfo=timezone.utc),
+    )
+    subtask.deleted_at = datetime(2026, 3, 2, 12, tzinfo=timezone.utc)
+    subtask.save(update_fields=["deleted_at"])
+
+    assert history(auth_client(user), *RANGE).json() == []
+
+    included = history(auth_client(user), *RANGE, include_deleted="true").json()
+    assert len(included) == 1
+    assert included[0]["deleted"] is True
+
+
+@pytest.mark.django_db
+def test_history_requires_authentication():
+    """Unauthenticated requests are rejected."""
+    assert history(Client(), *RANGE).status_code == 401


### PR DESCRIPTION
## History page

Replaces the "Coming soon" placeholder with a real, searchable history of tracked time, grouped by day — fulfilling the History roadmap item.

### Backend

- New endpoint `GET /ticktask/user/get-time-history/?start&end&include_deleted` (JWT, scoped to `request.auth`): returns the user's time entries whose `clock_in` falls within `[start, end]`, flattened with their subtask and task names and ordered newest first. Open (still-running) entries are included with a null `clock_out`.
- Soft-deleted subtasks/tasks are excluded by default and included (flagged `deleted: true`) when `include_deleted` is set — consistent with the dashboard and calendar.
- New `HistoryEntrySchema` in `time_entry_schema.py`.

### Frontend

- `pages/time-history.vue` (was a placeholder): entries **grouped by day**, with a date header and per-day total, each row showing the time range, `Task › Subtask`, and duration. Soft-deleted items are shown struck through with a `deleted` badge.
- Controls: a range selector (**7 / 30 / 90 days**), a **text search** over task/subtask names, and a **Show deleted** toggle. A summary line shows the entry count and total time tracked.
- Loading and empty states, and errors surfaced via toast. Uses the `useTasks` composable (new `getTimeHistory`) — no direct `$api`.

### Tests

- Backend (`test_history.py`): flattened output ordered newest-first, range filtering, inclusion of open entries, per-user scoping, `include_deleted` visibility, and authentication.