### PR TITLE
Calendar multi day

### DIFF
--- a/gui/pages/calendar.vue
+++ b/gui/pages/calendar.vue
@@ -103,12 +103,19 @@
 
           <div class="relative z-10 mt-1 space-y-1">
             <button
-              v-for="ev in (eventsByDay[dayKey(day)] || []).slice(0, 3)"
-              :key="ev.id"
-              class="flex w-full items-center rounded-md px-1.5 py-0.5 text-left text-[11px] font-medium text-white"
-              :style="{ backgroundColor: ev.color || '#007CBF' }"
-              @click.stop="openEdit(ev)">
-              <span class="truncate">{{ ev.title }}</span>
+              v-for="seg in (eventsByDay[dayKey(day)] || []).slice(0, 3)"
+              :key="seg.event.id"
+              class="flex min-h-[1.1rem] w-full items-center px-1.5 py-0.5 text-left text-[11px] font-medium text-white"
+              :class="[
+                seg.isStart || day.getDay() === 1 ? 'rounded-l-md' : '',
+                seg.isEnd || day.getDay() === 0 ? 'rounded-r-md' : '',
+              ]"
+              :style="{ backgroundColor: seg.event.color || '#007CBF' }"
+              :title="seg.event.title"
+              @click.stop="openEdit(seg.event)">
+              <span class="truncate">
+                {{ seg.isStart || day.getDay() === 1 ? seg.event.title : "" }}
+              </span>
             </button>
             <span
               v-if="(eventsByDay[dayKey(day)] || []).length > 3"
@@ -156,9 +163,9 @@
   const days = computed(() => buildMonthMatrix(cursor.value));
 
   const eventsByDay = computed(() => {
-    const map = {};
-    for (const ev of events.value) {
-      (map[dayKey(ev.start)] ||= []).push(ev);
+    const map = eventSegmentsByDay(events.value, days.value);
+    for (const key in map) {
+      map[key].sort((a, b) => new Date(a.event.start) - new Date(b.event.start));
     }
     return map;
   });

--- a/gui/pages/time-history.vue
+++ b/gui/pages/time-history.vue
@@ -135,6 +135,7 @@
     { value: "7", label: "7 days", days: 7 },
     { value: "30", label: "30 days", days: 30 },
     { value: "90", label: "90 days", days: 90 },
+    { value: "all", label: "All", days: null },
   ];
 
   const range = ref("30");
@@ -197,9 +198,15 @@
     try {
       const option = RANGES.find((r) => r.value === range.value);
       const end = new Date();
-      const start = new Date(end);
-      start.setDate(start.getDate() - option.days);
-      start.setHours(0, 0, 0, 0);
+      let start;
+      if (option.days === null) {
+        // "All" — reach back far enough to cover every entry.
+        start = new Date(0);
+      } else {
+        start = new Date(end);
+        start.setDate(start.getDate() - option.days);
+        start.setHours(0, 0, 0, 0);
+      }
       entries.value = await getTimeHistory(
         start.toISOString(),
         end.toISOString(),

--- a/gui/tests/calendar.test.js
+++ b/gui/tests/calendar.test.js
@@ -6,6 +6,7 @@ import {
   dayKey,
   isSameDay,
   isSameMonth,
+  eventSegmentsByDay,
 } from "../utils/calendar.js";
 
 describe("startOfMonth", () => {
@@ -53,5 +54,39 @@ describe("isSameDay / isSameMonth", () => {
   it("checks month membership", () => {
     expect(isSameMonth(new Date(2026, 6, 31), new Date(2026, 6, 1))).toBe(true);
     expect(isSameMonth(new Date(2026, 7, 1), new Date(2026, 6, 1))).toBe(false);
+  });
+});
+
+describe("eventSegmentsByDay", () => {
+  // Mon Mar 2 .. Sun Mar 8 2026 (local).
+  const week = Array.from({ length: 7 }, (_, i) => new Date(2026, 2, 2 + i));
+
+  it("places a single-day event only on its start day", () => {
+    const ev = { id: 1, start: new Date(2026, 2, 3, 9) };
+    const map = eventSegmentsByDay([ev], week);
+    expect(Object.keys(map)).toEqual(["2026-03-03"]);
+    expect(map["2026-03-03"][0]).toMatchObject({ isStart: true, isEnd: true });
+  });
+
+  it("spans every day a multi-day event covers, flagging start and end", () => {
+    const ev = { id: 2, start: new Date(2026, 2, 3, 9), end: new Date(2026, 2, 5, 11) };
+    const map = eventSegmentsByDay([ev], week);
+    expect(Object.keys(map).sort()).toEqual([
+      "2026-03-03",
+      "2026-03-04",
+      "2026-03-05",
+    ]);
+    expect(map["2026-03-03"][0]).toMatchObject({ isStart: true, isEnd: false });
+    expect(map["2026-03-04"][0]).toMatchObject({ isStart: false, isEnd: false });
+    expect(map["2026-03-05"][0]).toMatchObject({ isStart: false, isEnd: true });
+  });
+
+  it("clamps to the provided grid days", () => {
+    const ev = { id: 3, start: new Date(2026, 1, 28), end: new Date(2026, 2, 3) };
+    const map = eventSegmentsByDay([ev], week);
+    // Only Mar 2 and Mar 3 are within the week grid.
+    expect(Object.keys(map).sort()).toEqual(["2026-03-02", "2026-03-03"]);
+    expect(map["2026-03-02"][0].isStart).toBe(false); // started before the grid
+    expect(map["2026-03-03"][0].isEnd).toBe(true);
   });
 });

--- a/gui/utils/calendar.js
+++ b/gui/utils/calendar.js
@@ -43,6 +43,32 @@ export function isSameDay(a, b) {
   return dayKey(a) === dayKey(b);
 }
 
+/**
+ * Maps each event onto every grid day it covers, from its start day to its end
+ * day (inclusive). Events without an `end` cover only their start day. Returns
+ * `{ dayKey: [{ event, isStart, isEnd }] }` so a multi-day event shows on each
+ * day it spans instead of only on its start day.
+ */
+export function eventSegmentsByDay(events, days) {
+  const map = {};
+  for (const event of events) {
+    const a = dayKey(event.start);
+    const b = event.end ? dayKey(event.end) : a;
+    const [from, to] = a <= b ? [a, b] : [b, a];
+    for (const day of days) {
+      const key = dayKey(day);
+      if (key >= from && key <= to) {
+        (map[key] ||= []).push({
+          event,
+          isStart: key === from,
+          isEnd: key === to,
+        });
+      }
+    }
+  }
+  return map;
+}
+
 /** True if `value` is within the month of `monthDate`. */
 export function isSameMonth(value, monthDate) {
   const d = new Date(value);


### PR DESCRIPTION
## Multi-day calendar events + an "All" history range

Two small frontend polish items.

### Multi-day / all-day events on the calendar

Events that span more than one day previously rendered only on their start day. They now render across **every day they cover**.

- New pure helper `eventSegmentsByDay(events, days)` in `utils/calendar.js`: maps each event onto every grid day between its start and end day (inclusive), with `isStart` / `isEnd` flags, clamped to the visible days. Events without an `end` still cover only their start day.
- `calendar.vue` renders a colored bar on each covered day. The **title shows on the start day and at the start of each week**; intermediate days are continuation bars (with the title as a native tooltip). Corners round on the event's start/end and at week edges so it reads as a continuous bar.
- No backend change: the calendar query already returns events that overlap the visible range, so events spanning into the grid are fetched.

### "All" range on the history page

- The range selector gains an **"All"** option alongside 7 / 30 / 90 days; it reaches back far enough (epoch) to return every entry. Grouping, search, totals and the "Show deleted" toggle work unchanged.
- No backend change: `get-time-history` already accepts any range.

### Tests

- `calendar.test.js` (+3): `eventSegmentsByDay` for a single-day event, a multi-day event (start/end flags), and clamping to the grid.