### PR TITLE
Telegram interactive control

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,3 +15,13 @@ TELEGRAM_BOT_USERNAME=
 TELEGRAM_USE_WEBHOOK=False
 # Random secret embedded in the webhook URL path; only needed when using a webhook.
 TELEGRAM_WEBHOOK_SECRET=
+
+# Cache backend. Holds the Telegram bot's short-lived conversation state (the
+# multi-step "create task/subtask" flows). The default in-process cache is fine
+# for development (single long-polling process) and tests. In production behind
+# a webhook served by multiple workers, point this at Redis so the state is
+# shared across them:
+#   CACHE_BACKEND=django.core.cache.backends.redis.RedisCache
+#   CACHE_LOCATION=redis://localhost:6379/1
+CACHE_BACKEND=django.core.cache.backends.locmem.LocMemCache
+CACHE_LOCATION=ticktask-local

--- a/gui/pages/time-tracking.vue
+++ b/gui/pages/time-tracking.vue
@@ -273,6 +273,12 @@
   const activeTimeEntryId = ref(null);
   const recentTimeEntries = ref([]);
 
+  // Keep the tracker in sync with changes made outside this tab (e.g. clocking
+  // in/out from the Telegram bot, or the server auto-closing a stale entry).
+  const POLL_INTERVAL_MS = 7000;
+  let syncInterval = null;
+  const mutating = ref(false); // guards against polling mid clock-in/out
+
   const dialogAddTaskVisible = ref(false);
   const dialogAddSubTaskVisible = ref(false);
   const currentTaskForSubtask = ref(null);
@@ -302,26 +308,17 @@
       tasks.value = await fetchTasks();
 
       const active = await getClockedIn();
-      if (active) {
-        const subtask = active.subtasks[0];
-        const entry = subtask.time_entries[0];
-
-        selectedTask.value = active;
-        activeTask.value = active;
-        selectedSubtask.value = subtask;
-        activeSubTask.value = subtask;
-        activeTimeEntryId.value = entry.id;
-        isClockedIn.value = true;
-        clockInTime.value = new Date(entry.clock_in);
-        expanded.value = [active.id];
-        startClockInTimer();
-        fetchRecentTimeEntries(subtask.id);
-      }
+      if (active) applyActiveEntry(active);
     } catch (error) {
       console.error("Error fetching tasks:", error);
       toast.error("Couldn't load your tasks.");
     } finally {
       loadingTasks.value = false;
+    }
+
+    startSyncPolling();
+    if (typeof document !== "undefined") {
+      document.addEventListener("visibilitychange", handleVisibilityChange);
     }
   });
 
@@ -352,6 +349,7 @@
   }
 
   async function clockIn() {
+    mutating.value = true;
     try {
       const existing = await getClockedIn();
       if (existing) {
@@ -373,16 +371,21 @@
     } catch (err) {
       console.error("Error during clock in:", err);
       toast.error(err?.data?.detail || "Couldn't clock in.");
+    } finally {
+      mutating.value = false;
     }
   }
 
   async function clockOut() {
+    mutating.value = true;
     try {
       await apiClockOut(activeTimeEntryId.value);
       resetTracker();
     } catch (err) {
       console.error("Error during clock out:", err);
       toast.error("Couldn't clock out.");
+    } finally {
+      mutating.value = false;
     }
   }
 
@@ -397,9 +400,61 @@
 
   function startClockInTimer() {
     if (clockInterval) clearInterval(clockInterval);
+    clockInDuration.value = formatDuration(new Date() - clockInTime.value);
     clockInterval = setInterval(() => {
       clockInDuration.value = formatDuration(new Date() - clockInTime.value);
     }, 1000);
+  }
+
+  // Adopts the server's open entry as the active session in this tab.
+  function applyActiveEntry(active) {
+    const subtask = active.subtasks[0];
+    const entry = subtask.time_entries[0];
+
+    selectedTask.value = active;
+    activeTask.value = active;
+    selectedSubtask.value = subtask;
+    activeSubTask.value = subtask;
+    activeTimeEntryId.value = entry.id;
+    isClockedIn.value = true;
+    clockInTime.value = new Date(entry.clock_in);
+    if (!expanded.value.includes(active.id)) {
+      expanded.value = [...expanded.value, active.id];
+    }
+    startClockInTimer();
+    fetchRecentTimeEntries(subtask.id);
+  }
+
+  // Reconciles the local tracker with the server's open entry. Only acts when
+  // the open entry actually changed, so it won't disturb a running timer.
+  async function syncActiveState() {
+    if (mutating.value) return;
+    let active;
+    try {
+      active = await getClockedIn();
+    } catch {
+      return; // transient error; try again on the next tick
+    }
+
+    const serverEntryId = active?.subtasks?.[0]?.time_entries?.[0]?.id ?? null;
+    if (serverEntryId === activeTimeEntryId.value) return;
+
+    if (serverEntryId === null) {
+      resetTracker();
+      toast.info("Your active session was stopped elsewhere.");
+    } else {
+      applyActiveEntry(active);
+      toast.info("Synced your active session.");
+    }
+  }
+
+  function startSyncPolling() {
+    if (syncInterval) clearInterval(syncInterval);
+    syncInterval = setInterval(syncActiveState, POLL_INTERVAL_MS);
+  }
+
+  function handleVisibilityChange() {
+    if (!document.hidden) syncActiveState();
   }
 
   function openAddTaskDialog() {
@@ -486,5 +541,9 @@
 
   onBeforeUnmount(() => {
     if (clockInterval) clearInterval(clockInterval);
+    if (syncInterval) clearInterval(syncInterval);
+    if (typeof document !== "undefined") {
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+    }
   });
 </script>

--- a/ticktask/management/commands/run_telegram_bot.py
+++ b/ticktask/management/commands/run_telegram_bot.py
@@ -21,6 +21,11 @@ class Command(BaseCommand):
         if not telegram.is_configured():
             raise CommandError("TELEGRAM_BOT_TOKEN is not set.")
 
+        try:
+            telegram.set_my_commands()
+        except Exception as exc:  # pylint: disable=broad-except
+            self.stderr.write(f"Could not register bot commands: {exc}")
+
         self.stdout.write(self.style.SUCCESS("Polling Telegram… (Ctrl-C to stop)"))
         offset = None
         while True:

--- a/ticktask/management/commands/set_telegram_webhook.py
+++ b/ticktask/management/commands/set_telegram_webhook.py
@@ -43,4 +43,5 @@ class Command(BaseCommand):
             f"{settings.TELEGRAM_WEBHOOK_SECRET}/"
         )
         telegram.set_webhook(webhook_url)
+        telegram.set_my_commands()
         self.stdout.write(self.style.SUCCESS(f"Webhook set to {webhook_url}"))

--- a/ticktask/server/routes/tasks.py
+++ b/ticktask/server/routes/tasks.py
@@ -38,8 +38,14 @@ except RuntimeError:
 from ticktask.models import Task, SubTask, TimeEntry
 from django.db.models import Prefetch
 from django.utils import timezone
+from ticktask import services
 
 ticktask_router = Router()
+
+
+def _raise_http(exc: services.ServiceError):
+    """Translates a domain :class:`ServiceError` into a Ninja ``HttpError``."""
+    raise HttpError(exc.status, exc.message)
 
 
 @ticktask_router.get(
@@ -71,27 +77,10 @@ def create_task(request, data: TaskCreationSchema):
     """
     Creates a new task for the authenticated user.
     """
-    name = data.name.strip()
-    if not name:
-        raise HttpError(422, "El nombre de la tarea no puede estar vacío.")
-
-    existing = Task.objects.filter(  # pylint: disable=no-member
-        user=request.auth, name=name
-    ).first()
-    if existing is not None:
-        if existing.is_deleted:
-            raise HttpError(
-                409,
-                "Ya existe una tarea eliminada con ese nombre. "
-                "Restáurala en lugar de crear una nueva.",
-            )
-        raise HttpError(409, "Ya existe una tarea con ese nombre.")
-
-    task = Task.objects.create(  # pylint: disable=no-member
-        user=request.auth,
-        name=name,
-    )
-    return task
+    try:
+        return services.create_task(request.auth, data.name)
+    except services.ServiceError as exc:
+        _raise_http(exc)
 
 
 @ticktask_router.post(
@@ -105,31 +94,11 @@ def create_subtask(request, data: SubTaskCreationSchema):
     Creates a new subtask for the authenticated user.
     """
     try:
-        task = Task.objects.get(id=data.task_id, user=request.auth)  # pylint: disable=no-member
-    except Task.DoesNotExist:  # pylint: disable=no-member
-        return {"error": "Tarea no encontrada"}, 404
-
-    name = data.name.strip()
-    if not name:
-        raise HttpError(422, "El nombre de la subtarea no puede estar vacío.")
-
-    existing = SubTask.objects.filter(task=task, name=name).first()  # pylint: disable=no-member
-    if existing is not None:
-        if existing.is_deleted:
-            raise HttpError(
-                409,
-                "Ya existe una subtarea eliminada con ese nombre en esta tarea. "
-                "Restáurala en lugar de crear una nueva.",
-            )
-        raise HttpError(409, "Ya existe una subtarea con ese nombre en esta tarea.")
-
-    subtask = SubTask.objects.create(  # pylint: disable=no-member
-        name=name,
-        description=data.description.strip(),
-        task=task,
-    )
-
-    return subtask
+        return services.create_subtask(
+            request.auth, data.task_id, data.name, data.description
+        )
+    except services.ServiceError as exc:
+        _raise_http(exc)
 
 
 @ticktask_router.post(
@@ -247,17 +216,9 @@ def clock_in(request, data: ClockInSchema):
     Registers a new time entry to the corresponding subtask.
     """
     try:
-        subtask = SubTask.objects.select_related("task").get(id=data.subtask_id)  # pylint: disable=no-member
-    except SubTask.DoesNotExist:  # pylint: disable=no-member
-        return {"error": "Subtarea no encontrada"}, 404
-
-    if subtask.task.user != request.auth:
-        return {"error": "No autorizado para esta subtarea"}, 403
-    if subtask.is_deleted or subtask.task.is_deleted:
-        raise HttpError(409, "No se puede fichar en una subtarea eliminada.")
-    entry = TimeEntry.objects.create(subtask=subtask)  # pylint: disable=no-member
-
-    return entry
+        return services.clock_in(request.auth, data.subtask_id)
+    except services.ServiceError as exc:
+        _raise_http(exc)
 
 
 @ticktask_router.post(
@@ -271,18 +232,9 @@ def clock_out(request, data: ClockOutSchema):
     Updates the given TimeEntry with clock_out.
     """
     try:
-        entry = TimeEntry.objects.select_related("subtask__task").get(  # pylint: disable=no-member
-            id=data.entity_id, clock_out__isnull=True
-        )
-    except TimeEntry.DoesNotExist:  # pylint: disable=no-member
-        return {"error": "Entrada no encontrada o ya cerrada"}, 404
-
-    if entry.subtask.task.user != request.auth:
-        return {"error": "No autorizado para esta entrada de tiempo"}, 403
-
-    entry.clock_out = timezone.now()
-    entry.save()
-    return entry
+        return services.clock_out(request.auth, data.entity_id)
+    except services.ServiceError as exc:
+        _raise_http(exc)
 
 
 @ticktask_router.get(

--- a/ticktask/services.py
+++ b/ticktask/services.py
@@ -1,0 +1,206 @@
+"""
+Domain operations shared between the HTTP API and the Telegram bot.
+
+These functions own the business rules (ownership scoping, soft-delete checks,
+duplicate-name validation, the clock-in/out flow) so the same behaviour is used
+whether the user acts through the web API or from a chat. They raise
+:class:`ServiceError` (carrying an HTTP-style ``status`` and a user-facing
+``message``) instead of framework-specific exceptions; each caller translates
+that into its own error shape (``HttpError`` for the API, a reply for the bot).
+"""
+
+from datetime import timedelta
+
+from django.db.models import Q
+from django.utils import timezone
+
+from ticktask.models import Task, SubTask, TimeEntry, CalendarEvent
+
+
+class ServiceError(Exception):
+    """A domain error with an HTTP-style status code and a user-facing message."""
+
+    def __init__(self, status: int, message: str):
+        self.status = status
+        self.message = message
+        super().__init__(message)
+
+
+# --------------------------------------------------------------------------- #
+# Tasks & subtasks
+# --------------------------------------------------------------------------- #
+
+
+def list_active_tasks(user):
+    """Returns the user's active (non-deleted) tasks, ordered by name."""
+    return list(
+        Task.objects.filter(user=user, deleted_at__isnull=True).order_by("name")  # pylint: disable=no-member
+    )
+
+
+def list_active_subtasks(user, task_id: int):
+    """Returns the active subtasks of one of the user's tasks, ordered by name."""
+    task = _get_owned_task(user, task_id)
+    return list(
+        task.subtasks.filter(deleted_at__isnull=True).order_by("name")  # pylint: disable=no-member
+    )
+
+
+def create_task(user, name: str) -> Task:
+    """
+    Creates a task for ``user``. Raises :class:`ServiceError` on an empty name
+    (422) or a name already taken by an active or soft-deleted task (409).
+    """
+    name = (name or "").strip()
+    if not name:
+        raise ServiceError(422, "El nombre de la tarea no puede estar vacío.")
+
+    existing = Task.objects.filter(user=user, name=name).first()  # pylint: disable=no-member
+    if existing is not None:
+        if existing.is_deleted:
+            raise ServiceError(
+                409,
+                "Ya existe una tarea eliminada con ese nombre. "
+                "Restáurala en lugar de crear una nueva.",
+            )
+        raise ServiceError(409, "Ya existe una tarea con ese nombre.")
+
+    return Task.objects.create(user=user, name=name)  # pylint: disable=no-member
+
+
+def create_subtask(user, task_id: int, name: str, description: str = "") -> SubTask:
+    """
+    Creates a subtask under one of ``user``'s tasks. Raises
+    :class:`ServiceError` if the task is missing (404), the name is empty (422),
+    or the name clashes with an active/soft-deleted subtask of that task (409).
+    """
+    task = _get_owned_task(user, task_id)
+
+    name = (name or "").strip()
+    if not name:
+        raise ServiceError(422, "El nombre de la subtarea no puede estar vacío.")
+
+    existing = SubTask.objects.filter(task=task, name=name).first()  # pylint: disable=no-member
+    if existing is not None:
+        if existing.is_deleted:
+            raise ServiceError(
+                409,
+                "Ya existe una subtarea eliminada con ese nombre en esta tarea. "
+                "Restáurala en lugar de crear una nueva.",
+            )
+        raise ServiceError(
+            409, "Ya existe una subtarea con ese nombre en esta tarea."
+        )
+
+    return SubTask.objects.create(  # pylint: disable=no-member
+        name=name, description=(description or "").strip(), task=task
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Clock in / out
+# --------------------------------------------------------------------------- #
+
+
+def get_open_entry(user):
+    """Returns the user's currently open time entry (on a live task), or None."""
+    return (
+        TimeEntry.objects.select_related("subtask__task")  # pylint: disable=no-member
+        .filter(
+            clock_out__isnull=True,
+            subtask__task__user=user,
+            subtask__deleted_at__isnull=True,
+            subtask__task__deleted_at__isnull=True,
+        )
+        .first()
+    )
+
+
+def clock_in(user, subtask_id: int) -> TimeEntry:
+    """
+    Opens a time entry on one of ``user``'s subtasks. Raises
+    :class:`ServiceError` if the subtask is missing/not owned (404) or
+    soft-deleted (409).
+    """
+    subtask = _get_owned_subtask(user, subtask_id)
+    if subtask.is_deleted or subtask.task.is_deleted:
+        raise ServiceError(409, "No se puede fichar en una subtarea eliminada.")
+    return TimeEntry.objects.create(subtask=subtask)  # pylint: disable=no-member
+
+
+def clock_out(user, entry_id: int) -> TimeEntry:
+    """
+    Closes the given open time entry. Raises :class:`ServiceError` if it does
+    not exist, is already closed, or is not the user's (404).
+    """
+    entry = (
+        TimeEntry.objects.select_related("subtask__task")  # pylint: disable=no-member
+        .filter(id=entry_id, clock_out__isnull=True, subtask__task__user=user)
+        .first()
+    )
+    if entry is None:
+        raise ServiceError(404, "Entrada no encontrada o ya cerrada.")
+    entry.clock_out = timezone.now()
+    entry.save(update_fields=["clock_out"])
+    return entry
+
+
+# --------------------------------------------------------------------------- #
+# Read helpers (for the bot's list commands)
+# --------------------------------------------------------------------------- #
+
+
+def recent_time_entries(user, limit: int = 10):
+    """
+    Returns the user's most recent time entries (newest first) on live
+    tasks/subtasks, with their subtask and task preloaded.
+    """
+    return list(
+        TimeEntry.objects.select_related("subtask__task")  # pylint: disable=no-member
+        .filter(
+            subtask__task__user=user,
+            subtask__deleted_at__isnull=True,
+            subtask__task__deleted_at__isnull=True,
+        )
+        .order_by("-clock_in")[:limit]
+    )
+
+
+def upcoming_events(user, days: int = 7, limit: int = 10):
+    """
+    Returns the user's upcoming calendar events starting within the next
+    ``days`` days (or already ongoing), ordered by start.
+    """
+    now = timezone.now()
+    # Future events, plus ones already ongoing (started but not yet ended).
+    not_over_yet = Q(start__gte=now) | Q(end__gte=now)
+    return list(
+        CalendarEvent.objects.filter(  # pylint: disable=no-member
+            not_over_yet, user=user, start__lte=now + timedelta(days=days)
+        ).order_by("start")[:limit]
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Internal
+# --------------------------------------------------------------------------- #
+
+
+def _get_owned_task(user, task_id: int) -> Task:
+    """Fetches one of ``user``'s tasks or raises a 404 ServiceError."""
+    task = Task.objects.filter(id=task_id, user=user).first()  # pylint: disable=no-member
+    if task is None:
+        raise ServiceError(404, "Tarea no encontrada.")
+    return task
+
+
+def _get_owned_subtask(user, subtask_id: int) -> SubTask:
+    """Fetches one of ``user``'s subtasks or raises a 404 ServiceError."""
+    subtask = (
+        SubTask.objects.select_related("task")  # pylint: disable=no-member
+        .filter(id=subtask_id, task__user=user)
+        .first()
+    )
+    if subtask is None:
+        raise ServiceError(404, "Subtarea no encontrada.")
+    return subtask

--- a/ticktask/settings.py
+++ b/ticktask/settings.py
@@ -177,3 +177,19 @@ TELEGRAM_BOT_TOKEN = config("TELEGRAM_BOT_TOKEN", default="")
 TELEGRAM_BOT_USERNAME = config("TELEGRAM_BOT_USERNAME", default="")
 TELEGRAM_USE_WEBHOOK = config("TELEGRAM_USE_WEBHOOK", default=False, cast=bool)
 TELEGRAM_WEBHOOK_SECRET = config("TELEGRAM_WEBHOOK_SECRET", default="")
+
+# Cache backend. Used for the Telegram bot's short-lived conversation state
+# (multi-step flows keyed by chat). Defaults to in-process memory, which is
+# fine for development (single long-polling process) and tests. In production
+# with a webhook served by multiple workers, point this at Redis so the state
+# is shared, e.g. CACHE_BACKEND=django.core.cache.backends.redis.RedisCache and
+# CACHE_LOCATION=redis://localhost:6379/1.
+CACHES = {
+    "default": {
+        "BACKEND": config(
+            "CACHE_BACKEND",
+            default="django.core.cache.backends.locmem.LocMemCache",
+        ),
+        "LOCATION": config("CACHE_LOCATION", default="ticktask-local"),
+    }
+}

--- a/ticktask/telegram.py
+++ b/ticktask/telegram.py
@@ -1,8 +1,21 @@
 """
-Telegram bot integration: sending messages and handling incoming bot updates
-for account linking. All HTTP goes through ``_request`` so it can be stubbed in
-tests. The bot is a single app-wide credential (``TELEGRAM_BOT_TOKEN``); who to
-message is stored per user as a ``chat_id`` (see ``UserTelegramSettings``).
+Telegram bot integration.
+
+This module is the bot's transport + dispatch layer:
+
+* **Transport** — thin wrappers over the Bot API (``send_message``,
+  ``edit_message_text``, ``answer_callback_query``, ``get_updates``,
+  webhook/commands setup). All HTTP goes through ``_request`` so it can be
+  stubbed in tests.
+* **Dispatch** — ``process_update`` routes incoming updates: account linking
+  (``/start <token>``), read commands (``/tasks``, ``/events``), and
+  button-driven write actions (clock in/out, create task/subtask). Business
+  rules live in :mod:`ticktask.services`; this layer only formats messages and
+  builds inline keyboards. Multi-step flows keep short-lived per-chat state in
+  the Django cache.
+
+The bot is a single app-wide credential (``TELEGRAM_BOT_TOKEN``); who to message
+is stored per user as a ``chat_id`` (see ``UserTelegramSettings``).
 """
 
 import json
@@ -11,17 +24,41 @@ import urllib.request
 from datetime import timedelta
 
 from django.conf import settings
+from django.core.cache import cache
 from django.utils import timezone
+
+from ticktask import services
 
 logger = logging.getLogger(__name__)
 
 _API_URL = "https://api.telegram.org/bot{token}/{method}"
 LINK_TOKEN_TTL_MINUTES = 15
+# How long a multi-step flow (e.g. "create task" awaiting a name) stays active.
+STATE_TTL_SECONDS = 300
+# How many rows the list commands / pickers show at most.
+LIST_LIMIT = 10
+
+# Commands advertised in Telegram's "/" menu.
+BOT_COMMANDS = [
+    ("clockin", "Start tracking time on a subtask"),
+    ("clockout", "Stop the current time entry"),
+    ("tasks", "Show your recent activity"),
+    ("events", "Show your upcoming events"),
+    ("newtask", "Create a new task"),
+    ("newsubtask", "Create a new subtask"),
+    ("cancel", "Cancel the current action"),
+    ("help", "Show available commands"),
+]
 
 
 def is_configured() -> bool:
     """Whether a bot token is available."""
     return bool(settings.TELEGRAM_BOT_TOKEN)
+
+
+# --------------------------------------------------------------------------- #
+# Transport
+# --------------------------------------------------------------------------- #
 
 
 def _request(method: str, payload: dict) -> dict:
@@ -35,11 +72,32 @@ def _request(method: str, payload: dict) -> dict:
         return json.loads(response.read().decode())
 
 
-def send_message(chat_id, text: str) -> None:
+def send_message(chat_id, text: str, reply_markup: dict | None = None) -> None:
     """Sends a text message to a chat. Raises if the bot isn't configured."""
     if not is_configured():
         raise RuntimeError("Telegram bot is not configured (TELEGRAM_BOT_TOKEN).")
-    _request("sendMessage", {"chat_id": chat_id, "text": text})
+    payload = {"chat_id": chat_id, "text": text}
+    if reply_markup is not None:
+        payload["reply_markup"] = reply_markup
+    _request("sendMessage", payload)
+
+
+def edit_message_text(
+    chat_id, message_id, text: str, reply_markup: dict | None = None
+) -> None:
+    """Edits an existing message (used to advance inline-keyboard flows in place)."""
+    payload = {"chat_id": chat_id, "message_id": message_id, "text": text}
+    if reply_markup is not None:
+        payload["reply_markup"] = reply_markup
+    _request("editMessageText", payload)
+
+
+def answer_callback_query(callback_query_id, text: str | None = None) -> None:
+    """Acknowledges a button tap so Telegram stops the loading spinner."""
+    payload = {"callback_query_id": callback_query_id}
+    if text is not None:
+        payload["text"] = text
+    _request("answerCallbackQuery", payload)
 
 
 def get_updates(offset=None, timeout: int = 25) -> list:
@@ -60,30 +118,85 @@ def delete_webhook() -> dict:
     return _request("deleteWebhook", {})
 
 
+def set_my_commands() -> dict:
+    """Registers the command menu shown in Telegram's ``/`` picker."""
+    commands = [{"command": c, "description": d} for c, d in BOT_COMMANDS]
+    return _request("setMyCommands", {"commands": commands})
+
+
 def deep_link(token: str) -> str:
     """Builds the ``t.me`` deep link that starts the bot with a link token."""
     return f"https://t.me/{settings.TELEGRAM_BOT_USERNAME}?start={token}"
 
 
+# --------------------------------------------------------------------------- #
+# Dispatch
+# --------------------------------------------------------------------------- #
+
+
 def process_update(update: dict) -> None:
     """
-    Handles an incoming bot update. A ``/start <token>`` message links the
-    sending chat to the account that issued ``token``.
+    Routes an incoming bot update to the right handler: button taps
+    (``callback_query``), the ``/start`` linking flow, slash commands, or the
+    text reply that continues a multi-step flow.
     """
+    if "callback_query" in update:
+        _handle_callback(update["callback_query"])
+        return
+
     message = update.get("message") or {}
     text = (message.get("text") or "").strip()
     chat_id = (message.get("chat") or {}).get("id")
-    if not chat_id or not text.startswith("/start"):
+    if not chat_id:
         return
 
+    # Linking works before the chat is associated to any account.
+    if text.startswith("/start"):
+        _handle_start(chat_id, text)
+        return
+
+    user = _user_for_chat(chat_id)
+    if user is None:
+        _safe_send(chat_id, _NOT_LINKED)
+        return
+
+    if text.startswith("/"):
+        _clear_state(chat_id)  # a fresh command cancels any pending flow
+        _handle_command(user, chat_id, text)
+        return
+
+    # Plain text: it may be the answer to a "send me a name" prompt.
+    state = _get_state(chat_id)
+    if state:
+        _handle_state_input(user, chat_id, state, text)
+    else:
+        _send_help(chat_id)
+
+
+_NOT_LINKED = (
+    "This chat isn't connected to a TickTask account yet. Open TickTask "
+    "settings and use the connect link to get started."
+)
+
+
+# --------------------------------------------------------------------------- #
+# Linking (/start)
+# --------------------------------------------------------------------------- #
+
+
+def _handle_start(chat_id, text: str) -> None:
+    """Handles ``/start``: link with a token, else greet/help."""
     parts = text.split(maxsplit=1)
     token = parts[1].strip() if len(parts) > 1 else ""
-    if not token:
-        _safe_send(
-            chat_id, "Open the link from TickTask settings to connect your account."
-        )
+    if token:
+        _link_account(chat_id, token)
         return
-    _link_account(chat_id, token)
+    if _user_for_chat(chat_id) is not None:
+        _send_help(chat_id)
+        return
+    _safe_send(
+        chat_id, "Open the link from TickTask settings to connect your account."
+    )
 
 
 def _link_account(chat_id, token: str) -> None:
@@ -109,13 +222,373 @@ def _link_account(chat_id, token: str) -> None:
         update_fields=["chat_id", "connected_at", "link_token", "link_token_created_at"]
     )
     _safe_send(
-        chat_id, "✅ Connected to TickTask. You'll get your event reminders here."
+        chat_id,
+        "✅ Connected to TickTask. Send /help to see what I can do.",
     )
 
 
-def _safe_send(chat_id, text: str) -> None:
-    """Best-effort send that never raises (used inside update handling)."""
+# --------------------------------------------------------------------------- #
+# Commands
+# --------------------------------------------------------------------------- #
+
+
+def _handle_command(user, chat_id, text: str) -> None:
+    """Dispatches a ``/command`` (bot mention and arguments stripped)."""
+    word = text.split()[0].lstrip("/").lower()
+    cmd = word.split("@")[0]  # tolerate /clockin@TickTaskBot in groups
+    handler = {
+        "help": lambda u, c: _send_help(c),
+        "tasks": _cmd_recent,
+        "recent": _cmd_recent,
+        "events": _cmd_events,
+        "upcoming": _cmd_events,
+        "clockin": _cmd_clockin,
+        "clockout": _cmd_clockout,
+        "newtask": _cmd_newtask,
+        "newsubtask": _cmd_newsubtask,
+        "cancel": _cmd_cancel,
+    }.get(cmd)
+    if handler is None:
+        _send_help(chat_id)
+        return
+    handler(user, chat_id)
+
+
+def _send_help(chat_id) -> None:
+    """Lists the available commands."""
+    lines = ["Here's what I can do:"]
+    lines += [f"/{c} — {d}" for c, d in BOT_COMMANDS]
+    _safe_send(chat_id, "\n".join(lines))
+
+
+def _cmd_recent(user, chat_id) -> None:
+    """``/tasks`` — recent activity and the current open entry, if any."""
+    entries = services.recent_time_entries(user, limit=LIST_LIMIT)
+    if not entries:
+        _safe_send(chat_id, "No time tracked yet. Use /clockin to get started.")
+        return
+    lines = ["🕒 Recent activity:"]
+    for entry in entries:
+        label = _entry_label(entry)
+        if entry.clock_out is None:
+            lines.append(f"🟢 {label} — in progress")
+        else:
+            duration = _format_duration(entry.clock_out - entry.clock_in)
+            lines.append(f"• {label} — {duration}")
+    _safe_send(chat_id, "\n".join(lines))
+
+
+def _cmd_events(user, chat_id) -> None:
+    """``/events`` — upcoming calendar events for the next few days."""
+    events = services.upcoming_events(user, days=7, limit=LIST_LIMIT)
+    if not events:
+        _safe_send(chat_id, "No upcoming events in the next 7 days.")
+        return
+    lines = ["📅 Upcoming events:"]
+    for event in events:
+        lines.append(f"• {event.title} — {_format_event_when(event)}")
+    _safe_send(chat_id, "\n".join(lines))
+
+
+def _cmd_clockin(user, chat_id) -> None:
+    """``/clockin`` — offer to close the open entry, else show the task picker."""
+    open_entry = services.get_open_entry(user)
+    if open_entry is not None:
+        send_message(
+            chat_id,
+            f"You're already clocked in on {_entry_label(open_entry)}. "
+            "Clock out first?",
+            reply_markup=_inline([[("⏹ Clock out", f"co:{open_entry.id}")]]),
+        )
+        return
+    _show_task_picker(chat_id, user)
+
+
+def _cmd_clockout(user, chat_id) -> None:
+    """``/clockout`` — close the current open entry, if there is one."""
+    open_entry = services.get_open_entry(user)
+    if open_entry is None:
+        _safe_send(chat_id, "You're not clocked in right now.")
+        return
+    _do_clock_out(chat_id, user, open_entry.id)
+
+
+def _cmd_newtask(user, chat_id) -> None:
+    """``/newtask`` — ask for a name, then create the task."""
+    _start_new_task(chat_id)
+
+
+def _cmd_newsubtask(user, chat_id) -> None:
+    """``/newsubtask`` — pick the parent task, then ask for a name."""
+    tasks = services.list_active_tasks(user)
+    if not tasks:
+        _safe_send(chat_id, "You have no tasks yet. Create one with /newtask first.")
+        return
+    rows = [[(t.name, f"ci:news:{t.id}")] for t in tasks]
+    send_message(
+        chat_id, "Which task is the subtask for?", reply_markup=_inline(rows)
+    )
+
+
+def _cmd_cancel(user, chat_id) -> None:
+    """``/cancel`` — drop any pending multi-step flow."""
+    if _get_state(chat_id) is not None:
+        _clear_state(chat_id)
+        _safe_send(chat_id, "Okay, cancelled.")
+    else:
+        _safe_send(chat_id, "Nothing to cancel.")
+
+
+# --------------------------------------------------------------------------- #
+# Button taps (callback queries)
+# --------------------------------------------------------------------------- #
+
+
+def _handle_callback(callback: dict) -> None:
+    """Handles an inline-keyboard tap, then acknowledges it."""
+    data = callback.get("data") or ""
+    message = callback.get("message") or {}
+    chat_id = (message.get("chat") or {}).get("id")
+    message_id = message.get("message_id")
+
+    callback_id = callback.get("id")
+    if callback_id is not None:
+        _safe(lambda: answer_callback_query(callback_id))
+
+    if not chat_id:
+        return
+    user = _user_for_chat(chat_id)
+    if user is None:
+        _safe_send(chat_id, _NOT_LINKED)
+        return
+    _route_callback(user, chat_id, message_id, data)
+
+
+def _route_callback(user, chat_id, message_id, data: str) -> None:
+    """Dispatches a callback by its compact ``data`` token."""
+    parts = data.split(":")
+    kind = parts[0]
+
+    if kind == "co":  # clock out a specific entry
+        _do_clock_out(chat_id, user, int(parts[1]), message_id=message_id)
+        return
+
+    if kind == "ci":
+        action = parts[1] if len(parts) > 1 else ""
+        if action == "tasks":
+            _show_task_picker(chat_id, user, message_id=message_id)
+        elif action == "t":
+            _show_subtask_picker(chat_id, user, int(parts[2]), message_id=message_id)
+        elif action == "s":
+            _do_clock_in(chat_id, user, int(parts[2]), message_id=message_id)
+        elif action == "newt":
+            _start_new_task(chat_id)
+        elif action == "news":
+            _start_new_subtask(chat_id, int(parts[2]))
+
+
+def _show_task_picker(chat_id, user, message_id=None) -> None:
+    """Shows the user's tasks as buttons leading into the clock-in flow."""
+    tasks = services.list_active_tasks(user)
+    rows = [[(t.name, f"ci:t:{t.id}")] for t in tasks]
+    rows.append([("➕ New task", "ci:newt")])
+    text = "Pick a task:" if tasks else "You have no tasks yet — create one:"
+    _send_or_edit(chat_id, message_id, text, reply_markup=_inline(rows))
+
+
+def _show_subtask_picker(chat_id, user, task_id, message_id=None) -> None:
+    """Shows a task's subtasks as buttons, plus create/back actions."""
     try:
-        send_message(chat_id, text)
+        subtasks = services.list_active_subtasks(user, task_id)
+    except services.ServiceError as exc:
+        _send_or_edit(chat_id, message_id, f"⚠️ {exc.message}")
+        return
+    rows = [[(s.name, f"ci:s:{s.id}")] for s in subtasks]
+    rows.append([("➕ New subtask", f"ci:news:{task_id}")])
+    rows.append([("⬅ Back", "ci:tasks")])
+    text = "Pick a subtask to clock in:" if subtasks else "No subtasks yet — add one:"
+    _send_or_edit(chat_id, message_id, text, reply_markup=_inline(rows))
+
+
+def _do_clock_in(chat_id, user, subtask_id, message_id=None) -> None:
+    """Clocks in on a subtask, refusing if an entry is already open."""
+    open_entry = services.get_open_entry(user)
+    if open_entry is not None:
+        _send_or_edit(
+            chat_id,
+            message_id,
+            f"⚠️ You're already clocked in on {_entry_label(open_entry)}. "
+            "Use /clockout first.",
+        )
+        return
+    try:
+        entry = services.clock_in(user, subtask_id)
+    except services.ServiceError as exc:
+        _send_or_edit(chat_id, message_id, f"⚠️ {exc.message}")
+        return
+    _send_or_edit(chat_id, message_id, f"✅ Clocked in on {_entry_label(entry)}.")
+
+
+def _do_clock_out(chat_id, user, entry_id, message_id=None) -> None:
+    """Clocks out the given entry and reports the tracked duration."""
+    try:
+        entry = services.clock_out(user, entry_id)
+    except services.ServiceError as exc:
+        _send_or_edit(chat_id, message_id, f"⚠️ {exc.message}")
+        return
+    duration = _format_duration(entry.clock_out - entry.clock_in)
+    _send_or_edit(
+        chat_id,
+        message_id,
+        f"⏹ Clocked out of {_entry_label(entry)}. Tracked {duration}.",
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Multi-step create flows (ForceReply + cached state)
+# --------------------------------------------------------------------------- #
+
+
+def _start_new_task(chat_id) -> None:
+    """Prompts for a task name and remembers we're awaiting it."""
+    _set_state(chat_id, {"action": "new_task"})
+    send_message(
+        chat_id,
+        "Send a name for the new task (or /cancel):",
+        reply_markup={"force_reply": True},
+    )
+
+
+def _start_new_subtask(chat_id, task_id) -> None:
+    """Prompts for a subtask name under ``task_id``."""
+    _set_state(chat_id, {"action": "new_subtask", "task_id": task_id})
+    send_message(
+        chat_id,
+        "Send a name for the new subtask (or /cancel):",
+        reply_markup={"force_reply": True},
+    )
+
+
+def _handle_state_input(user, chat_id, state: dict, text: str) -> None:
+    """Consumes the text reply that completes a pending create flow."""
+    action = state.get("action")
+    if action == "new_task":
+        _clear_state(chat_id)
+        try:
+            task = services.create_task(user, text)
+        except services.ServiceError as exc:
+            _safe_send(chat_id, f"⚠️ {exc.message}")
+            return
+        _show_subtask_picker(chat_id, user, task.id)
+    elif action == "new_subtask":
+        _clear_state(chat_id)
+        try:
+            subtask = services.create_subtask(user, state["task_id"], text)
+        except services.ServiceError as exc:
+            _safe_send(chat_id, f"⚠️ {exc.message}")
+            return
+        send_message(
+            chat_id,
+            f"✅ Created {_subtask_label(subtask)}.",
+            reply_markup=_inline([[("▶️ Clock in", f"ci:s:{subtask.id}")]]),
+        )
+    else:
+        _clear_state(chat_id)
+
+
+# --------------------------------------------------------------------------- #
+# Formatting & small helpers
+# --------------------------------------------------------------------------- #
+
+
+def _inline(rows) -> dict:
+    """Builds an inline keyboard from rows of ``(text, callback_data)`` tuples."""
+    return {
+        "inline_keyboard": [
+            [{"text": text, "callback_data": data} for text, data in row]
+            for row in rows
+        ]
+    }
+
+
+def _send_or_edit(chat_id, message_id, text, reply_markup=None) -> None:
+    """Edits the message in place when continuing a button flow, else sends new."""
+    if message_id is not None:
+        _safe(lambda: edit_message_text(chat_id, message_id, text, reply_markup))
+    else:
+        _safe_send(chat_id, text, reply_markup)
+
+
+def _entry_label(entry) -> str:
+    """``Task ▸ Subtask`` label for a time entry."""
+    return f"{entry.subtask.task.name} ▸ {entry.subtask.name}"
+
+
+def _subtask_label(subtask) -> str:
+    """``Task ▸ Subtask`` label for a subtask."""
+    return f"{subtask.task.name} ▸ {subtask.name}"
+
+
+def _format_duration(delta) -> str:
+    """Formats a ``timedelta`` as a compact ``Hh Mm`` string."""
+    total_minutes = int(delta.total_seconds() // 60)
+    hours, minutes = divmod(total_minutes, 60)
+    if hours and minutes:
+        return f"{hours}h {minutes}m"
+    if hours:
+        return f"{hours}h"
+    return f"{minutes}m"
+
+
+def _format_event_when(event) -> str:
+    """Formats an event's start for display (UTC for now)."""
+    if event.all_day:
+        return event.start.strftime("%Y-%m-%d (all day)")
+    return event.start.strftime("%Y-%m-%d %H:%M UTC")
+
+
+def _user_for_chat(chat_id):
+    """Returns the account linked to ``chat_id``, or None."""
+    from ticktask.models import UserTelegramSettings  # pylint: disable=import-outside-toplevel
+
+    row = (
+        UserTelegramSettings.objects.filter(chat_id=str(chat_id))  # pylint: disable=no-member
+        .select_related("user")
+        .first()
+    )
+    return row.user if row is not None else None
+
+
+# --- conversation state (per chat, short-lived) ---------------------------- #
+
+
+def _state_key(chat_id) -> str:
+    return f"tg:state:{chat_id}"
+
+
+def _get_state(chat_id):
+    return cache.get(_state_key(chat_id))
+
+
+def _set_state(chat_id, state: dict) -> None:
+    cache.set(_state_key(chat_id), state, STATE_TTL_SECONDS)
+
+
+def _clear_state(chat_id) -> None:
+    cache.delete(_state_key(chat_id))
+
+
+# --- best-effort sending (never raises inside update handling) ------------- #
+
+
+def _safe(func) -> None:
+    """Runs a Bot API call, swallowing and logging any error."""
+    try:
+        func()
     except Exception:  # pylint: disable=broad-except
-        logger.exception("Failed to send Telegram message to %s", chat_id)
+        logger.exception("Telegram Bot API call failed")
+
+
+def _safe_send(chat_id, text: str, reply_markup: dict | None = None) -> None:
+    """Best-effort send that never raises (used inside update handling)."""
+    _safe(lambda: send_message(chat_id, text, reply_markup))

--- a/ticktask/tests/test_telegram_bot.py
+++ b/ticktask/tests/test_telegram_bot.py
@@ -1,0 +1,381 @@
+"""
+Tests for the interactive Telegram bot: command dispatch, the clock-in/out
+button flows, the create-task/subtask conversation flows, and the unlinked-chat
+path. The Bot API HTTP layer (``telegram._request``) is stubbed, so no network
+calls are made and we assert on the payloads the bot would have sent.
+"""
+
+from datetime import timedelta
+
+import pytest
+from django.core.cache import cache
+from django.utils import timezone
+from django.contrib.auth.models import User
+
+from ticktask import telegram
+from ticktask.models import (
+    Task,
+    SubTask,
+    TimeEntry,
+    CalendarEvent,
+    UserTelegramSettings,
+)
+
+CHAT_ID = 42
+
+
+@pytest.fixture(autouse=True)
+def stub_telegram_http(monkeypatch):
+    """Stubs the Bot API HTTP layer and records every call made."""
+    calls = []
+
+    def fake_request(method, payload):
+        calls.append((method, payload))
+        return {"ok": True, "result": []}
+
+    monkeypatch.setattr(telegram, "_request", fake_request)
+    return calls
+
+
+@pytest.fixture(autouse=True)
+def bot_config(settings):
+    """Provides a configured bot."""
+    settings.TELEGRAM_BOT_TOKEN = "test-token"
+    settings.TELEGRAM_BOT_USERNAME = "TickTaskBot"
+    return settings
+
+
+@pytest.fixture(autouse=True)
+def clear_state():
+    """Conversation state lives in the cache; isolate it per test."""
+    cache.clear()
+    yield
+    cache.clear()
+
+
+# --------------------------------------------------------------------------- #
+# Helpers
+# --------------------------------------------------------------------------- #
+
+
+def linked_user(username="alice", chat_id=CHAT_ID) -> User:
+    """Creates a user with a Telegram chat already linked."""
+    user = User.objects.create_user(username=username, password="pw")
+    UserTelegramSettings.objects.create(  # pylint: disable=no-member
+        user=user, chat_id=str(chat_id), connected_at=timezone.now()
+    )
+    return user
+
+
+def command(text, chat_id=CHAT_ID):
+    return {"message": {"text": text, "chat": {"id": chat_id}}}
+
+
+def text_reply(text, chat_id=CHAT_ID):
+    return {"message": {"text": text, "chat": {"id": chat_id}}}
+
+
+def callback(data, chat_id=CHAT_ID, message_id=100):
+    return {
+        "callback_query": {
+            "id": "cb",
+            "data": data,
+            "message": {"message_id": message_id, "chat": {"id": chat_id}},
+        }
+    }
+
+
+def sent_texts(calls):
+    """Texts of every sendMessage / editMessageText call."""
+    return [
+        p["text"]
+        for m, p in calls
+        if m in ("sendMessage", "editMessageText")
+    ]
+
+
+def last_markup(calls):
+    """The reply_markup of the last send/edit call that had one."""
+    for _, payload in reversed(calls):
+        if "reply_markup" in payload:
+            return payload["reply_markup"]
+    return None
+
+
+def callback_datas(markup):
+    """All callback_data strings in an inline keyboard."""
+    if not markup or "inline_keyboard" not in markup:
+        return []
+    return [btn["callback_data"] for row in markup["inline_keyboard"] for btn in row]
+
+
+# --------------------------------------------------------------------------- #
+# Linking / unlinked chat
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.django_db
+def test_unlinked_chat_is_told_to_connect(stub_telegram_http):
+    """A command from a chat with no account gets a connect prompt."""
+    telegram.process_update(command("/tasks", chat_id=999))
+    assert any("connect" in t.lower() for t in sent_texts(stub_telegram_http))
+
+
+@pytest.mark.django_db
+def test_start_with_token_still_links(stub_telegram_http):
+    """The /start linking flow keeps working alongside the new commands."""
+    user = User.objects.create_user(username="bob", password="pw")
+    row = UserTelegramSettings.objects.create(  # pylint: disable=no-member
+        user=user, link_token="tok", link_token_created_at=timezone.now()
+    )
+
+    telegram.process_update(command("/start tok", chat_id=77))
+
+    row.refresh_from_db()
+    assert row.chat_id == "77"
+
+
+# --------------------------------------------------------------------------- #
+# Read commands
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.django_db
+def test_help_lists_commands(stub_telegram_http):
+    linked_user()
+    telegram.process_update(command("/help"))
+    text = "\n".join(sent_texts(stub_telegram_http))
+    assert "/clockin" in text and "/events" in text
+
+
+@pytest.mark.django_db
+def test_tasks_lists_recent_activity(stub_telegram_http):
+    user = linked_user()
+    task = Task.objects.create(user=user, name="Proj")  # pylint: disable=no-member
+    sub = SubTask.objects.create(task=task, name="Code", description="")  # pylint: disable=no-member
+    now = timezone.now()
+    TimeEntry.objects.create(  # pylint: disable=no-member
+        subtask=sub, clock_in=now - timedelta(hours=2), clock_out=now - timedelta(hours=1)
+    )
+
+    telegram.process_update(command("/tasks"))
+
+    text = "\n".join(sent_texts(stub_telegram_http))
+    assert "Proj ▸ Code" in text
+    assert "1h" in text
+
+
+@pytest.mark.django_db
+def test_tasks_marks_open_entry_in_progress(stub_telegram_http):
+    user = linked_user()
+    task = Task.objects.create(user=user, name="Proj")  # pylint: disable=no-member
+    sub = SubTask.objects.create(task=task, name="Code", description="")  # pylint: disable=no-member
+    TimeEntry.objects.create(subtask=sub)  # pylint: disable=no-member  (open)
+
+    telegram.process_update(command("/tasks"))
+    assert any("in progress" in t for t in sent_texts(stub_telegram_http))
+
+
+@pytest.mark.django_db
+def test_events_lists_upcoming(stub_telegram_http):
+    user = linked_user()
+    CalendarEvent.objects.create(  # pylint: disable=no-member
+        user=user, title="Standup", start=timezone.now() + timedelta(days=1)
+    )
+    CalendarEvent.objects.create(  # pylint: disable=no-member
+        user=user, title="Old", start=timezone.now() - timedelta(days=3)
+    )
+
+    telegram.process_update(command("/events"))
+
+    text = "\n".join(sent_texts(stub_telegram_http))
+    assert "Standup" in text
+    assert "Old" not in text
+
+
+@pytest.mark.django_db
+def test_events_empty_state(stub_telegram_http):
+    linked_user()
+    telegram.process_update(command("/events"))
+    assert any("No upcoming events" in t for t in sent_texts(stub_telegram_http))
+
+
+# --------------------------------------------------------------------------- #
+# Clock-in flow (buttons)
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.django_db
+def test_clockin_shows_task_picker(stub_telegram_http):
+    user = linked_user()
+    task = Task.objects.create(user=user, name="Proj")  # pylint: disable=no-member
+
+    telegram.process_update(command("/clockin"))
+
+    datas = callback_datas(last_markup(stub_telegram_http))
+    assert f"ci:t:{task.id}" in datas
+    assert "ci:newt" in datas
+
+
+@pytest.mark.django_db
+def test_clockin_pick_task_shows_subtasks(stub_telegram_http):
+    user = linked_user()
+    task = Task.objects.create(user=user, name="Proj")  # pylint: disable=no-member
+    sub = SubTask.objects.create(task=task, name="Code", description="")  # pylint: disable=no-member
+
+    telegram.process_update(callback(f"ci:t:{task.id}"))
+
+    datas = callback_datas(last_markup(stub_telegram_http))
+    assert f"ci:s:{sub.id}" in datas
+    assert f"ci:news:{task.id}" in datas
+    assert "ci:tasks" in datas  # back button
+
+
+@pytest.mark.django_db
+def test_clockin_pick_subtask_creates_entry(stub_telegram_http):
+    user = linked_user()
+    task = Task.objects.create(user=user, name="Proj")  # pylint: disable=no-member
+    sub = SubTask.objects.create(task=task, name="Code", description="")  # pylint: disable=no-member
+
+    telegram.process_update(callback(f"ci:s:{sub.id}"))
+
+    entry = TimeEntry.objects.get(subtask=sub)  # pylint: disable=no-member
+    assert entry.clock_out is None
+    assert any("Clocked in" in t for t in sent_texts(stub_telegram_http))
+
+
+@pytest.mark.django_db
+def test_clockin_answers_the_callback_query(stub_telegram_http):
+    user = linked_user()
+    task = Task.objects.create(user=user, name="Proj")  # pylint: disable=no-member
+    SubTask.objects.create(task=task, name="Code", description="")  # pylint: disable=no-member
+
+    telegram.process_update(callback(f"ci:t:{task.id}"))
+    assert any(m == "answerCallbackQuery" for m, _ in stub_telegram_http)
+
+
+@pytest.mark.django_db
+def test_clockin_blocked_when_already_clocked_in(stub_telegram_http):
+    user = linked_user()
+    task = Task.objects.create(user=user, name="Proj")  # pylint: disable=no-member
+    sub = SubTask.objects.create(task=task, name="Code", description="")  # pylint: disable=no-member
+    open_entry = TimeEntry.objects.create(subtask=sub)  # pylint: disable=no-member
+
+    telegram.process_update(command("/clockin"))
+
+    datas = callback_datas(last_markup(stub_telegram_http))
+    assert f"co:{open_entry.id}" in datas  # offered a clock-out button
+
+
+@pytest.mark.django_db
+def test_callback_clock_in_rejected_on_deleted_subtask(stub_telegram_http):
+    user = linked_user()
+    task = Task.objects.create(user=user, name="Proj")  # pylint: disable=no-member
+    sub = SubTask.objects.create(  # pylint: disable=no-member
+        task=task, name="Code", description="", deleted_at=timezone.now()
+    )
+
+    telegram.process_update(callback(f"ci:s:{sub.id}"))
+
+    assert not TimeEntry.objects.filter(subtask=sub).exists()  # pylint: disable=no-member
+    assert any("⚠️" in t for t in sent_texts(stub_telegram_http))
+
+
+# --------------------------------------------------------------------------- #
+# Clock-out
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.django_db
+def test_clockout_closes_open_entry(stub_telegram_http):
+    user = linked_user()
+    task = Task.objects.create(user=user, name="Proj")  # pylint: disable=no-member
+    sub = SubTask.objects.create(task=task, name="Code", description="")  # pylint: disable=no-member
+    entry = TimeEntry.objects.create(  # pylint: disable=no-member
+        subtask=sub, clock_in=timezone.now() - timedelta(minutes=90)
+    )
+
+    telegram.process_update(command("/clockout"))
+
+    entry.refresh_from_db()
+    assert entry.clock_out is not None
+    assert any("Clocked out" in t for t in sent_texts(stub_telegram_http))
+
+
+@pytest.mark.django_db
+def test_clockout_when_not_clocked_in(stub_telegram_http):
+    linked_user()
+    telegram.process_update(command("/clockout"))
+    assert any("not clocked in" in t.lower() for t in sent_texts(stub_telegram_http))
+
+
+# --------------------------------------------------------------------------- #
+# Create flows (ForceReply + state)
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.django_db
+def test_newtask_flow_creates_task(stub_telegram_http):
+    user = linked_user()
+
+    telegram.process_update(command("/newtask"))
+    # Bot should prompt with a ForceReply.
+    assert any(
+        p.get("reply_markup", {}).get("force_reply")
+        for m, p in stub_telegram_http
+        if m == "sendMessage"
+    )
+
+    telegram.process_update(text_reply("Marketing"))
+    assert Task.objects.filter(user=user, name="Marketing").exists()  # pylint: disable=no-member
+
+
+@pytest.mark.django_db
+def test_newtask_duplicate_name_is_reported(stub_telegram_http):
+    user = linked_user()
+    Task.objects.create(user=user, name="Dup")  # pylint: disable=no-member
+
+    telegram.process_update(command("/newtask"))
+    telegram.process_update(text_reply("Dup"))
+
+    assert Task.objects.filter(user=user, name="Dup").count() == 1  # pylint: disable=no-member
+    assert any("⚠️" in t for t in sent_texts(stub_telegram_http))
+
+
+@pytest.mark.django_db
+def test_newsubtask_flow_creates_subtask(stub_telegram_http):
+    user = linked_user()
+    task = Task.objects.create(user=user, name="Proj")  # pylint: disable=no-member
+
+    telegram.process_update(command("/newsubtask"))
+    # Pick the parent task.
+    datas = callback_datas(last_markup(stub_telegram_http))
+    assert f"ci:news:{task.id}" in datas
+
+    telegram.process_update(callback(f"ci:news:{task.id}"))
+    telegram.process_update(text_reply("Design"))
+
+    assert SubTask.objects.filter(task=task, name="Design").exists()  # pylint: disable=no-member
+
+
+@pytest.mark.django_db
+def test_cancel_drops_pending_flow(stub_telegram_http):
+    user = linked_user()
+
+    telegram.process_update(command("/newtask"))
+    telegram.process_update(command("/cancel"))
+    telegram.process_update(text_reply("ShouldNotExist"))
+
+    assert not Task.objects.filter(user=user, name="ShouldNotExist").exists()  # pylint: disable=no-member
+
+
+@pytest.mark.django_db
+def test_new_command_cancels_previous_flow(stub_telegram_http):
+    """Starting a new command mid-flow drops the old pending action."""
+    user = linked_user()
+
+    telegram.process_update(command("/newtask"))
+    telegram.process_update(command("/help"))  # interrupts the flow
+    telegram.process_update(text_reply("Orphan"))
+
+    assert not Task.objects.filter(user=user, name="Orphan").exists()  # pylint: disable=no-member


### PR DESCRIPTION
## Telegram interactive control

Turns the Telegram bot from link-only into a full **control surface**: the user
can query their data *and* act — clock in/out, list and pick a task/subtask, and
create tasks/subtasks — all from the chat, button-driven so it's easy on mobile.
The chat is already tied to an account via `chat_id`, so the bot resolves the
user with no extra auth.

### Bot commands

- **`/clockin`** — sends the task list as inline buttons → pick a task → pick a
  subtask → clocks in. If an entry is already open it offers to clock out first,
  and every picker has a "➕ New task / subtask" shortcut into the create flow.
- **`/clockout`** — closes the open entry and reports the tracked duration.
- **`/newtask` / `/newsubtask`** — `ForceReply`-driven create flows with the same
  duplicate-name validation as the API.
- **`/tasks`** (`/recent`) — recent activity (task ▸ subtask + duration), with the
  current open entry flagged as in progress.
- **`/events`** (`/upcoming`) — upcoming calendar events for the next 7 days.
- **`/help`** and **`/cancel`**, plus the `/` command menu registered via
  `setMyCommands`.

The existing `/start <token>` account-linking flow is unchanged.

### How it works

- **Shared services layer (`ticktask/services.py`).** The create / clock-in /
  clock-out business rules and read queries were extracted out of the task
  routes so the API and the bot share one source of truth. Services raise a
  `ServiceError(status, message)`; the routes translate it back into `HttpError`,
  preserving the existing status codes and messages.
- **`process_update` is now a router** that dispatches on `message` (slash
  commands + `ForceReply` text) and `callback_query` (button taps), on top of the
  `/start` linking branch.
- **Conversation state** for multi-step flows (e.g. "create task" → awaiting a
  name) is kept per chat in the Django cache, short-lived and cancellable. It
  defaults to in-process memory (fine for the long-polling dev/bot process and
  tests) and is Redis-backed in production via `CACHE_BACKEND` / `CACHE_LOCATION`.

### Frontend: keep time tracking in sync

Because state can now change from outside the web app, the **time tracking page
polls the open entry** (every 7s) and reconciles the local tracker:

- clocked out elsewhere (Telegram / server auto-close) → the tracker resets;
- clocked in elsewhere → the tracker adopts that session.

It also syncs immediately when the tab regains focus, and guards against polling
mid clock-in/out. No backend change for this — purely a reactivity fix.

### Tests

New `test_telegram_bot.py` stubs the Bot API HTTP layer and covers command
dispatch, the clock-in/out button flows, the create-task/subtask conversation
flows, and the unlinked-chat path. The full suite passes (100 tests).

### Config

- `CACHE_BACKEND` / `CACHE_LOCATION` added to `.env.example`. Defaults keep dev
  and CI working with no Redis dependency; set them to the Redis cache backend
  when serving the bot via a multi-worker webhook.

### Notes / out of scope

- Times are shown in **UTC** (with a suffix) for now; a per-user display
  timezone is left for later.
- A `/today` command and a "…and N more" footer for long lists were left as
  follow-ups; lists currently cap silently.
