### PR TITLE
Dashboard weekly hours

### DIFF
--- a/gui/components/dashboard/WeeklyShare.vue
+++ b/gui/components/dashboard/WeeklyShare.vue
@@ -1,0 +1,45 @@
+<template>
+  <div v-if="tasks.length" class="space-y-4">
+    <div v-for="(task, index) in tasks" :key="task.task_id">
+      <div class="flex items-center gap-2">
+        <span
+          class="size-2.5 shrink-0 rounded-full"
+          :style="{ backgroundColor: chartColor(index) }"
+          :class="{ 'opacity-40': task.deleted }"></span>
+        <span
+          class="min-w-0 flex-1 truncate text-sm font-medium"
+          :class="{ 'text-muted-foreground line-through': task.deleted }">
+          {{ task.task_name }}
+        </span>
+        <span class="shrink-0 text-sm font-semibold tabular-nums">
+          {{ task.percent }}%
+        </span>
+        <span class="shrink-0 text-xs text-muted-foreground tabular-nums">
+          {{ formatHours(task.hours) }}
+        </span>
+      </div>
+
+      <div class="mt-1.5 h-2 overflow-hidden rounded-full bg-muted">
+        <div
+          class="h-full rounded-full transition-all"
+          :style="{
+            width: `${task.percent}%`,
+            backgroundColor: chartColor(index),
+          }"></div>
+      </div>
+    </div>
+  </div>
+
+  <div
+    v-else
+    class="flex h-full min-h-[180px] flex-col items-center justify-center gap-2 text-center text-muted-foreground">
+    <Icon name="lucide:chart-no-axes-column" class="size-7" />
+    <p class="text-sm">No time tracked in the last 7 days.</p>
+  </div>
+</template>
+
+<script setup>
+  defineProps({
+    tasks: { type: Array, default: () => [] },
+  });
+</script>

--- a/gui/composables/useDashboard.js
+++ b/gui/composables/useDashboard.js
@@ -14,5 +14,11 @@ export function useDashboard() {
         method: "GET",
         query: { start, end, bucket, include_deleted: includeDeleted },
       }),
+
+    getWeeklyTaskHours: (includeDeleted = false) =>
+      $api("/dashboard/user/get-weekly-task-hours/", {
+        method: "GET",
+        query: { include_deleted: includeDeleted },
+      }),
   };
 }

--- a/gui/pages/dashboard.vue
+++ b/gui/pages/dashboard.vue
@@ -85,6 +85,20 @@
         </div>
       </UiCard>
     </div>
+
+    <!-- Share of the last 7 days, per task -->
+    <UiCard title="This week by task" subtitle="Share of time tracked in the last 7 days">
+      <div class="relative min-h-[200px]">
+        <div
+          v-if="weeklyLoading"
+          class="absolute inset-0 z-10 flex items-center justify-center rounded-xl bg-card/60 backdrop-blur-sm">
+          <Icon
+            name="lucide:loader-circle"
+            class="size-6 animate-spin text-muted-foreground" />
+        </div>
+        <DashboardWeeklyShare :tasks="weekly?.tasks || []" />
+      </div>
+    </UiCard>
   </div>
 </template>
 
@@ -97,7 +111,7 @@
     layout: "defaultlogged",
   });
 
-  const { getSummary, getTimeSeries } = useDashboard();
+  const { getSummary, getTimeSeries, getWeeklyTaskHours } = useDashboard();
   const { restoreTask: apiRestoreTask, restoreSubtask: apiRestoreSubtask } =
     useTasks();
   const toast = useToast();
@@ -107,6 +121,8 @@
   const summary = ref(null);
   const series = ref(null);
   const seriesLoading = ref(false);
+  const weekly = ref(null);
+  const weeklyLoading = ref(false);
 
   const statCards = computed(() => {
     const s = summary.value;
@@ -155,6 +171,18 @@
     }
   }
 
+  async function loadWeekly() {
+    weeklyLoading.value = true;
+    try {
+      weekly.value = await getWeeklyTaskHours(includeDeleted.value);
+    } catch (err) {
+      console.error("Error loading weekly task hours:", err);
+      toast.error("Couldn't load this week's breakdown.");
+    } finally {
+      weeklyLoading.value = false;
+    }
+  }
+
   async function loadSeries() {
     seriesLoading.value = true;
     try {
@@ -177,7 +205,7 @@
     try {
       await apiRestoreTask(taskId);
       toast.success("Task restored.");
-      await Promise.all([loadSummary(), loadSeries()]);
+      await Promise.all([loadSummary(), loadSeries(), loadWeekly()]);
     } catch (err) {
       console.error("Error restoring task:", err);
       toast.error("Couldn't restore the task.");
@@ -188,14 +216,16 @@
     try {
       await apiRestoreSubtask(subtaskId);
       toast.success("Subtask restored.");
-      await Promise.all([loadSummary(), loadSeries()]);
+      await Promise.all([loadSummary(), loadSeries(), loadWeekly()]);
     } catch (err) {
       console.error("Error restoring subtask:", err);
       toast.error("Couldn't restore the subtask.");
     }
   }
 
-  onMounted(loadSummary);
+  onMounted(() => Promise.all([loadSummary(), loadWeekly()]));
   watch(bucket, loadSeries, { immediate: true });
-  watch(includeDeleted, () => Promise.all([loadSummary(), loadSeries()]));
+  watch(includeDeleted, () =>
+    Promise.all([loadSummary(), loadSeries(), loadWeekly()]),
+  );
 </script>

--- a/ticktask/server/routes/dashboard.py
+++ b/ticktask/server/routes/dashboard.py
@@ -19,6 +19,7 @@ from ninja_jwt.authentication import JWTAuth
 from ticktask.server.schemas.dashboard_schema import (
     DashboardSummarySchema,
     TimeSeriesSchema,
+    WeeklyTaskHoursSchema,
 )
 
 try:
@@ -127,6 +128,71 @@ def get_summary(request, include_deleted: bool = False):
         "month_hours": _hours(month),
         "total_hours": _hours(total),
         "active_tasks": active_tasks,
+    }
+
+
+@dashboard_router.get(
+    "/user/get-weekly-task-hours/",
+    response=WeeklyTaskHoursSchema,
+    tags=["Dashboard"],
+    auth=JWTAuth(),
+)
+def get_weekly_task_hours(request, include_deleted: bool = False):
+    """
+    Returns the hours tracked per task over the trailing 7 days, with each
+    task's share (``percent``) of the total tracked that week. Only tasks with
+    time in the window are returned (sorted by hours, most first); soft-deleted
+    tasks/subtasks are excluded unless ``include_deleted`` is set.
+    """
+    now = timezone.now()
+    start = now - timedelta(days=7)
+
+    entries = _filter_deleted(
+        TimeEntry.objects.select_related("subtask__task").filter(  # pylint: disable=no-member
+            subtask__task__user=request.auth,
+            clock_out__isnull=False,
+            clock_in__gte=start,
+            clock_in__lte=now,
+        ),
+        include_deleted,
+    )
+
+    totals: dict[int, dict] = {}
+    grand = timedelta()
+    for entry in entries:
+        duration = entry.clock_out - entry.clock_in
+        grand += duration
+        task = entry.subtask.task
+        agg = totals.setdefault(
+            task.id,
+            {"name": task.name, "deleted": task.is_deleted, "total": timedelta()},
+        )
+        agg["total"] += duration
+
+    grand_seconds = grand.total_seconds()
+    tasks = [
+        {
+            "task_id": task_id,
+            "task_name": agg["name"],
+            "deleted": agg["deleted"],
+            "hours": _hours(agg["total"]),
+            "percent": (
+                round(agg["total"].total_seconds() / grand_seconds * 100, 1)
+                if grand_seconds
+                else 0.0
+            ),
+        }
+        for task_id, agg in sorted(
+            totals.items(),
+            key=lambda kv: (-kv[1]["total"].total_seconds(), kv[1]["name"].lower()),
+        )
+    ]
+
+    return {
+        "start": start,
+        "end": now,
+        "total_hours": _hours(grand),
+        "tasks": tasks,
     }
 
 

--- a/ticktask/server/schemas/dashboard_schema.py
+++ b/ticktask/server/schemas/dashboard_schema.py
@@ -68,3 +68,29 @@ class TimeSeriesSchema(Schema):
     end: datetime
     buckets: list[TimeSeriesBucketSchema]
     by_task: list[TaskHoursSchema]
+
+
+class WeeklyTaskShareSchema(Schema):
+    """
+    One task's tracked hours over the last week and its share (``percent``) of
+    the total time tracked that week.
+    """
+
+    task_id: int
+    task_name: str
+    hours: float
+    percent: float
+    deleted: bool = False
+
+
+class WeeklyTaskHoursSchema(Schema):
+    """
+    Per-task tracked hours over the trailing 7 days, each as a share of the
+    week's total. Only tasks with time tracked in the window are included, so
+    the shares add up to ~100% of what was actually tracked.
+    """
+
+    start: datetime
+    end: datetime
+    total_hours: float
+    tasks: list[WeeklyTaskShareSchema]

--- a/ticktask/tests/test_dashboard.py
+++ b/ticktask/tests/test_dashboard.py
@@ -49,6 +49,67 @@ def iso(dt: datetime) -> str:
 
 
 # --------------------------------------------------------------------------- #
+# Weekly task hours (share of the last 7 days)
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.django_db
+def test_weekly_task_hours_shares():
+    """Each task's hours and its percent of the week's total are returned."""
+    user = make_user()
+    now = dj_timezone.now()
+    a = make_subtask(user, "Alpha", "s")
+    b = make_subtask(user, "Beta", "s")
+    # 3h on Alpha and 1h on Beta, both within the last 7 days → 75% / 25%.
+    make_entry(a, now - timedelta(days=1), now - timedelta(days=1) + timedelta(hours=3))
+    make_entry(b, now - timedelta(days=2), now - timedelta(days=2) + timedelta(hours=1))
+
+    body = auth_client(user).get(f"{BASE}/get-weekly-task-hours/").json()
+
+    assert body["total_hours"] == 4.0
+    names = [t["task_name"] for t in body["tasks"]]
+    assert names == ["Alpha", "Beta"]  # sorted by hours, most first
+    by_name = {t["task_name"]: t for t in body["tasks"]}
+    assert by_name["Alpha"]["hours"] == 3.0 and by_name["Alpha"]["percent"] == 75.0
+    assert by_name["Beta"]["percent"] == 25.0
+
+
+@pytest.mark.django_db
+def test_weekly_task_hours_excludes_old_and_untracked():
+    """Entries older than 7 days and tasks with no recent time are left out."""
+    user = make_user()
+    now = dj_timezone.now()
+    recent = make_subtask(user, "Recent", "s")
+    old = make_subtask(user, "Old", "s")
+    make_entry(recent, now - timedelta(hours=2), now - timedelta(hours=1))
+    make_entry(old, now - timedelta(days=10), now - timedelta(days=10) + timedelta(hours=5))
+
+    body = auth_client(user).get(f"{BASE}/get-weekly-task-hours/").json()
+
+    assert [t["task_name"] for t in body["tasks"]] == ["Recent"]
+    assert body["tasks"][0]["percent"] == 100.0
+
+
+@pytest.mark.django_db
+def test_weekly_task_hours_excludes_deleted_by_default():
+    """Soft-deleted tasks are hidden unless include_deleted is set."""
+    user = make_user()
+    now = dj_timezone.now()
+    sub = make_subtask(user, "Gone", "s")
+    make_entry(sub, now - timedelta(hours=2), now - timedelta(hours=1))
+    Task.objects.filter(name="Gone", user=user).update(deleted_at=now)  # pylint: disable=no-member
+
+    client = auth_client(user)
+    assert client.get(f"{BASE}/get-weekly-task-hours/").json()["tasks"] == []
+
+    with_deleted = client.get(
+        f"{BASE}/get-weekly-task-hours/", {"include_deleted": "true"}
+    ).json()
+    assert [t["task_name"] for t in with_deleted["tasks"]] == ["Gone"]
+    assert with_deleted["tasks"][0]["deleted"] is True
+
+
+# --------------------------------------------------------------------------- #
 # Summary
 # --------------------------------------------------------------------------- #
 


### PR DESCRIPTION
## Dashboard: this week by task

Adds a **"This week by task"** panel to the dashboard: a horizontal progress bar per task whose width is the task's **share (%) of the time tracked in the last 7 days**, with the hours alongside. It answers "where did my week actually go?" at a glance — no estimates or targets involved.

### How it works

- **Endpoint** `GET /dashboard/user/get-weekly-task-hours/`: aggregates closed time entries over the trailing 7 days and returns `total_hours` plus, per task, its `hours` and `percent` of that total. Only tasks with time in the window are returned (sorted by hours, most first); soft-deleted tasks/subtasks are excluded unless `include_deleted` is set, matching the dashboard's "Show deleted" toggle. Reuses the existing aggregation helpers; no model change, so no migration.
- **Frontend**: a new `DashboardWeeklyShare` component renders one bar per task (width = its percent) using the existing color palette and `formatHours`, with an empty state when nothing was tracked. Wired through a `getWeeklyTaskHours` composable call and loaded on mount, when "Show deleted" changes, and after restoring a task/subtask.