### PR TITLE
Calendar week day views

### DIFF
--- a/gui/components/CalendarTimeGrid.vue
+++ b/gui/components/CalendarTimeGrid.vue
@@ -1,0 +1,193 @@
+<template>
+  <div class="overflow-hidden rounded-xl border border-border">
+    <!-- Day headers -->
+    <div class="grid border-b border-border bg-muted/30" :style="colsStyle">
+      <div class="border-r border-border"></div>
+      <div
+        v-for="day in days"
+        :key="dayKey(day)"
+        class="border-r border-border px-2 py-2 text-center last:border-r-0">
+        <div class="text-xs font-medium uppercase text-muted-foreground">
+          {{ day.toLocaleDateString([], { weekday: "short" }) }}
+        </div>
+        <div
+          class="mx-auto mt-0.5 flex size-7 items-center justify-center rounded-full text-sm font-semibold"
+          :class="
+            isToday(day) ? 'bg-primary text-primary-foreground' : 'text-foreground'
+          ">
+          {{ day.getDate() }}
+        </div>
+        <div
+          v-if="trackedByDay[dayKey(day)]"
+          class="mt-0.5 text-[10px] font-semibold text-accent">
+          {{ compactDuration(trackedByDay[dayKey(day)]) }}
+        </div>
+      </div>
+    </div>
+
+    <!-- All-day strip -->
+    <div
+      v-if="hasAllDay"
+      class="grid border-b border-border bg-background/40"
+      :style="colsStyle">
+      <div
+        class="border-r border-border px-1 py-1 text-right text-[10px] uppercase text-muted-foreground">
+        All day
+      </div>
+      <div
+        v-for="day in days"
+        :key="dayKey(day)"
+        class="space-y-1 border-r border-border p-1 last:border-r-0">
+        <button
+          v-for="ev in layouts[dayKey(day)].allDay"
+          :key="`${ev.id}-${ev.start}`"
+          class="block w-full truncate rounded px-1.5 py-0.5 text-left text-[11px] font-medium text-white"
+          :style="{ backgroundColor: ev.color || '#007CBF' }"
+          @click="emit('edit', ev)">
+          {{ ev.recurrence ? "↻ " : "" }}{{ ev.title }}
+        </button>
+      </div>
+    </div>
+
+    <!-- Scrollable time grid -->
+    <div ref="scroller" class="max-h-[62vh] overflow-y-auto">
+      <div class="grid" :style="colsStyle">
+        <!-- Hour gutter -->
+        <div class="border-r border-border">
+          <div
+            v-for="hour in 24"
+            :key="hour"
+            class="relative border-t border-border/60 text-right"
+            :style="{ height: `${HOUR_HEIGHT}px` }">
+            <span class="pr-1 text-[10px] text-muted-foreground">
+              {{ hourLabel(hour - 1) }}
+            </span>
+          </div>
+        </div>
+
+        <!-- Day columns -->
+        <div
+          v-for="day in days"
+          :key="dayKey(day)"
+          class="relative border-r border-border last:border-r-0"
+          @click="createAt($event, day)">
+          <div
+            v-for="hour in 24"
+            :key="hour"
+            class="border-t border-border/60"
+            :style="{ height: `${HOUR_HEIGHT}px` }"></div>
+
+          <button
+            v-for="seg in layouts[dayKey(day)].timed"
+            :key="`${seg.event.id}-${seg.event.start}`"
+            class="absolute overflow-hidden rounded-md px-1.5 py-0.5 text-left text-[11px] font-medium text-white shadow-soft"
+            :style="blockStyle(seg)"
+            :title="seg.event.title"
+            @click.stop="emit('edit', seg.event)">
+            <span class="block truncate">
+              {{ seg.event.recurrence ? "↻ " : "" }}{{ seg.event.title }}
+            </span>
+            <span class="block truncate opacity-80">{{
+              timeLabel(seg.event.start)
+            }}</span>
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+  import { ref, computed, onMounted } from "vue";
+
+  const props = defineProps({
+    days: { type: Array, required: true },
+    events: { type: Array, default: () => [] },
+    timeEntries: { type: Array, default: () => [] },
+  });
+
+  const emit = defineEmits(["create", "edit"]);
+
+  const HOUR_HEIGHT = 48;
+  const scroller = ref(null);
+
+  const colsStyle = computed(() => ({
+    gridTemplateColumns: `3.5rem repeat(${props.days.length}, minmax(0, 1fr))`,
+  }));
+
+  // Pre-compute each day's all-day + timed layout, keyed by day.
+  const layouts = computed(() => {
+    const map = {};
+    for (const day of props.days) {
+      map[dayKey(day)] = dayEventLayout(props.events, day);
+    }
+    return map;
+  });
+
+  const hasAllDay = computed(() =>
+    props.days.some((day) => layouts.value[dayKey(day)].allDay.length),
+  );
+
+  const trackedByDay = computed(() => {
+    const map = {};
+    for (const entry of props.timeEntries) {
+      const start = new Date(entry.clock_in);
+      const end = entry.clock_out ? new Date(entry.clock_out) : new Date();
+      const key = dayKey(start);
+      map[key] = (map[key] || 0) + (end - start);
+    }
+    return map;
+  });
+
+  function isToday(day) {
+    return isSameDay(day, new Date());
+  }
+
+  function hourLabel(hour) {
+    if (hour === 0) return "";
+    return `${String(hour).padStart(2, "0")}:00`;
+  }
+
+  function timeLabel(value) {
+    return new Date(value).toLocaleTimeString([], {
+      hour: "2-digit",
+      minute: "2-digit",
+    });
+  }
+
+  function compactDuration(ms) {
+    const minutes = Math.round(ms / 60000);
+    const h = Math.floor(minutes / 60);
+    const m = minutes % 60;
+    if (h && m) return `${h}h ${m}m`;
+    if (h) return `${h}h`;
+    return `${m}m`;
+  }
+
+  function blockStyle(seg) {
+    const gap = 2;
+    const width = 100 / seg.cols;
+    return {
+      top: `${(seg.startMin / 60) * HOUR_HEIGHT}px`,
+      height: `${((seg.endMin - seg.startMin) / 60) * HOUR_HEIGHT - gap}px`,
+      left: `calc(${seg.col * width}% + 2px)`,
+      width: `calc(${width}% - 4px)`,
+      backgroundColor: seg.event.color || "#007CBF",
+    };
+  }
+
+  function createAt(e, day) {
+    const rect = e.currentTarget.getBoundingClientRect();
+    const y = e.clientY - rect.top;
+    const snapped = Math.round((y / HOUR_HEIGHT) * 2) * 30; // nearest 30 min
+    const minutes = Math.max(0, Math.min(23 * 60 + 30, snapped));
+    const date = new Date(day.getFullYear(), day.getMonth(), day.getDate());
+    date.setMinutes(minutes);
+    emit("create", date);
+  }
+
+  onMounted(() => {
+    // Open scrolled to the start of the working day (07:00).
+    if (scroller.value) scroller.value.scrollTop = 7 * HOUR_HEIGHT;
+  });
+</script>

--- a/gui/pages/calendar.vue
+++ b/gui/pages/calendar.vue
@@ -24,26 +24,39 @@
 
     <UiCard padded>
       <!-- Toolbar -->
-      <div class="mb-4 flex items-center justify-between gap-3">
+      <div class="mb-4 flex flex-wrap items-center justify-between gap-3">
         <div class="flex items-center gap-2">
           <UiButton
             variant="outline"
             size="icon"
             icon="lucide:chevron-left"
-            @click="prevMonth" />
+            @click="goPrev" />
           <UiButton
             variant="outline"
             size="icon"
             icon="lucide:chevron-right"
-            @click="nextMonth" />
+            @click="goNext" />
           <UiButton variant="ghost" size="sm" @click="goToday">Today</UiButton>
         </div>
-        <h2 class="text-lg font-semibold capitalize">
-          {{ monthLabel(cursor) }}
-        </h2>
-        <div class="w-[88px]"></div>
+        <h2 class="text-lg font-semibold capitalize">{{ title }}</h2>
+        <div class="inline-flex rounded-xl border border-border p-0.5">
+          <button
+            v-for="option in views"
+            :key="option"
+            class="rounded-lg px-3 py-1 text-sm font-medium capitalize transition-colors"
+            :class="
+              view === option
+                ? 'bg-primary text-primary-foreground shadow-soft'
+                : 'text-muted-foreground hover:text-foreground'
+            "
+            @click="view = option">
+            {{ option }}
+          </button>
+        </div>
       </div>
 
+      <!-- Month view -->
+      <template v-if="view === 'month'">
       <!-- Weekday headers -->
       <div class="grid grid-cols-7 gap-1.5 pb-1.5">
         <div
@@ -129,6 +142,24 @@
           </div>
         </div>
       </div>
+      </template>
+
+      <!-- Week / Day view -->
+      <div v-else class="relative">
+        <div
+          v-if="loading"
+          class="absolute inset-0 z-20 flex items-center justify-center rounded-xl bg-card/60 backdrop-blur-sm">
+          <Icon
+            name="lucide:loader-circle"
+            class="size-6 animate-spin text-muted-foreground" />
+        </div>
+        <CalendarTimeGrid
+          :days="days"
+          :events="events"
+          :time-entries="timeEntries"
+          @create="openCreateAt"
+          @edit="openEdit" />
+      </div>
     </UiCard>
 
     <EventDialog
@@ -154,6 +185,8 @@
 
   const weekdays = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
 
+  const views = ["month", "week", "day"];
+  const view = ref("month");
   const cursor = ref(new Date());
   const events = ref([]);
   const timeEntries = ref([]);
@@ -164,7 +197,31 @@
   const editingEvent = ref(null);
   const defaultStart = ref(null);
 
-  const days = computed(() => buildMonthMatrix(cursor.value));
+  const days = computed(() => {
+    if (view.value === "week") return weekDays(cursor.value);
+    if (view.value === "day") {
+      const c = cursor.value;
+      return [new Date(c.getFullYear(), c.getMonth(), c.getDate())];
+    }
+    return buildMonthMatrix(cursor.value);
+  });
+
+  const title = computed(() => {
+    if (view.value === "day") {
+      return cursor.value.toLocaleDateString([], {
+        weekday: "long",
+        month: "long",
+        day: "numeric",
+      });
+    }
+    if (view.value === "week") {
+      const ds = days.value;
+      const fmt = (d) =>
+        d.toLocaleDateString([], { month: "short", day: "numeric" });
+      return `${fmt(ds[0])} – ${fmt(ds[ds.length - 1])}`;
+    }
+    return monthLabel(cursor.value);
+  });
 
   const eventsByDay = computed(() => {
     const map = eventSegmentsByDay(events.value, days.value);
@@ -235,12 +292,18 @@
     }
   }
 
-  function prevMonth() {
-    cursor.value = addMonths(cursor.value, -1);
+  function shift(amount) {
+    if (view.value === "week") cursor.value = addWeeks(cursor.value, amount);
+    else if (view.value === "day") cursor.value = addDays(cursor.value, amount);
+    else cursor.value = addMonths(cursor.value, amount);
   }
 
-  function nextMonth() {
-    cursor.value = addMonths(cursor.value, 1);
+  function goPrev() {
+    shift(-1);
+  }
+
+  function goNext() {
+    shift(1);
   }
 
   function goToday() {
@@ -248,9 +311,15 @@
   }
 
   function openCreate(day) {
-    editingEvent.value = null;
+    // Month view: a day cell → default to 9:00 on that day.
     const d = new Date(day.getFullYear(), day.getMonth(), day.getDate(), 9, 0);
-    defaultStart.value = d.toISOString();
+    openCreateAt(d);
+  }
+
+  function openCreateAt(date) {
+    // Week/day view: an exact clicked time.
+    editingEvent.value = null;
+    defaultStart.value = date.toISOString();
     dialogOpen.value = true;
   }
 
@@ -261,5 +330,6 @@
   }
 
   watch(cursor, load, { immediate: true });
+  watch(view, load);
   watch(includeDeleted, load);
 </script>

--- a/gui/tests/calendar.test.js
+++ b/gui/tests/calendar.test.js
@@ -2,11 +2,17 @@ import { describe, it, expect } from "vitest";
 import {
   startOfMonth,
   addMonths,
+  addDays,
+  addWeeks,
+  startOfWeek,
+  weekDays,
   buildMonthMatrix,
   dayKey,
   isSameDay,
   isSameMonth,
   eventSegmentsByDay,
+  dayEventLayout,
+  packEventColumns,
 } from "../utils/calendar.js";
 
 describe("startOfMonth", () => {
@@ -88,5 +94,103 @@ describe("eventSegmentsByDay", () => {
     expect(Object.keys(map).sort()).toEqual(["2026-03-02", "2026-03-03"]);
     expect(map["2026-03-02"][0].isStart).toBe(false); // started before the grid
     expect(map["2026-03-03"][0].isEnd).toBe(true);
+  });
+});
+
+describe("week helpers", () => {
+  it("startOfWeek returns the Monday of the week", () => {
+    // 2026-03-04 is a Wednesday.
+    expect(dayKey(startOfWeek(new Date(2026, 2, 4)))).toBe("2026-03-02");
+  });
+
+  it("weekDays returns Mon→Sun", () => {
+    const days = weekDays(new Date(2026, 2, 4));
+    expect(days.map(dayKey)).toEqual([
+      "2026-03-02",
+      "2026-03-03",
+      "2026-03-04",
+      "2026-03-05",
+      "2026-03-06",
+      "2026-03-07",
+      "2026-03-08",
+    ]);
+  });
+
+  it("addDays / addWeeks shift correctly", () => {
+    expect(dayKey(addDays(new Date(2026, 2, 4), 5))).toBe("2026-03-09");
+    expect(dayKey(addWeeks(new Date(2026, 2, 4), -1))).toBe("2026-02-25");
+  });
+});
+
+describe("packEventColumns", () => {
+  it("places non-overlapping segments in a single column", () => {
+    const out = packEventColumns([
+      { startMin: 60, endMin: 120 },
+      { startMin: 180, endMin: 240 },
+    ]);
+    expect(out.every((s) => s.cols === 1 && s.col === 0)).toBe(true);
+  });
+
+  it("splits two overlapping segments into two columns", () => {
+    const out = packEventColumns([
+      { startMin: 60, endMin: 180 },
+      { startMin: 120, endMin: 240 },
+    ]);
+    expect(out.map((s) => s.cols)).toEqual([2, 2]);
+    expect(new Set(out.map((s) => s.col))).toEqual(new Set([0, 1]));
+  });
+
+  it("reuses a column once an earlier segment has ended", () => {
+    const out = packEventColumns([
+      { startMin: 0, endMin: 60 },
+      { startMin: 30, endMin: 90 },
+      { startMin: 70, endMin: 120 }, // overlaps the 2nd but not the 1st
+    ]);
+    const byStart = Object.fromEntries(out.map((s) => [s.startMin, s]));
+    expect(byStart[70].col).toBe(0); // free again after the first ended at 60
+  });
+});
+
+describe("dayEventLayout", () => {
+  const day = new Date(2026, 2, 4); // Wed
+
+  it("separates all-day from timed events", () => {
+    const events = [
+      { id: 1, title: "Holiday", all_day: true, start: new Date(2026, 2, 4, 0) },
+      {
+        id: 2,
+        title: "Call",
+        all_day: false,
+        start: new Date(2026, 2, 4, 9),
+        end: new Date(2026, 2, 4, 10),
+      },
+    ];
+    const { allDay, timed } = dayEventLayout(events, day);
+    expect(allDay.map((e) => e.id)).toEqual([1]);
+    expect(timed).toHaveLength(1);
+    expect(timed[0]).toMatchObject({ startMin: 540, endMin: 600 });
+  });
+
+  it("treats an event spanning the whole day as all-day", () => {
+    const events = [
+      {
+        id: 3,
+        title: "Trip",
+        start: new Date(2026, 2, 3, 8),
+        end: new Date(2026, 2, 6, 8),
+      },
+    ];
+    const { allDay, timed } = dayEventLayout(events, day);
+    expect(allDay).toHaveLength(1);
+    expect(timed).toHaveLength(0);
+  });
+
+  it("clips a timed event to the day and gives open-ended ones an hour", () => {
+    const events = [
+      { id: 4, title: "Open", start: new Date(2026, 2, 4, 23), end: null },
+    ];
+    const { timed } = dayEventLayout(events, day);
+    expect(timed[0].startMin).toBe(1380); // 23:00
+    expect(timed[0].endMin).toBe(1440); // clipped to midnight
   });
 });

--- a/gui/utils/calendar.js
+++ b/gui/utils/calendar.js
@@ -13,6 +13,100 @@ export function addMonths(date, n) {
   return new Date(date.getFullYear(), date.getMonth() + n, 1);
 }
 
+/** Returns a new date shifted by `n` days (n can be negative), at midnight. */
+export function addDays(date, n) {
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate() + n);
+}
+
+/** Monday (00:00) of the week containing `date`. */
+export function startOfWeek(date) {
+  const offset = (date.getDay() + 6) % 7; // Monday = 0
+  return addDays(date, -offset);
+}
+
+/** Returns a new date shifted by `n` weeks (n can be negative). */
+export function addWeeks(date, n) {
+  return addDays(date, n * 7);
+}
+
+/** The seven days (Mon→Sun) of the week containing `date`, each at midnight. */
+export function weekDays(date) {
+  const start = startOfWeek(date);
+  return Array.from({ length: 7 }, (_, i) => addDays(start, i));
+}
+
+/**
+ * Lays out a day's events for a time-grid (week/day) view. Splits them into
+ * `allDay` (all-day events or ones covering the whole day) and `timed` segments
+ * clipped to the day, each with `startMin`/`endMin` (minutes from midnight) and
+ * a `col`/`cols` pair packing overlapping events side by side.
+ */
+export function dayEventLayout(events, day) {
+  const dayStart = new Date(day.getFullYear(), day.getMonth(), day.getDate());
+  const dayEnd = addDays(dayStart, 1);
+  const allDay = [];
+  const raw = [];
+
+  for (const event of events) {
+    const start = new Date(event.start);
+    const end = event.end
+      ? new Date(event.end)
+      : new Date(start.getTime() + 60 * 60000); // default 1h for open-ended
+    if (end <= dayStart || start >= dayEnd) continue; // doesn't touch this day
+
+    if (event.all_day || (start <= dayStart && end >= dayEnd)) {
+      allDay.push(event);
+      continue;
+    }
+
+    const startMin = Math.max(0, (start - dayStart) / 60000);
+    let endMin = Math.min(1440, (end - dayStart) / 60000);
+    if (endMin - startMin < 30) endMin = startMin + 30; // keep it visible
+    raw.push({ event, startMin, endMin });
+  }
+
+  return { allDay, timed: packEventColumns(raw) };
+}
+
+/**
+ * Greedy column packing for overlapping timed segments: each segment gets a
+ * `col` index and the `cols` count of its overlap cluster, so the UI can place
+ * concurrent events side by side (`width = 100/cols%`, `left = col*width`).
+ */
+export function packEventColumns(segments) {
+  const segs = [...segments].sort(
+    (a, b) => a.startMin - b.startMin || a.endMin - b.endMin,
+  );
+  const result = [];
+  let cluster = [];
+  let clusterEnd = -1;
+
+  const flush = () => {
+    const colEnds = [];
+    for (const seg of cluster) {
+      let col = colEnds.findIndex((end) => seg.startMin >= end);
+      if (col === -1) {
+        col = colEnds.length;
+        colEnds.push(seg.endMin);
+      } else {
+        colEnds[col] = seg.endMin;
+      }
+      seg.col = col;
+    }
+    for (const seg of cluster) result.push({ ...seg, cols: colEnds.length });
+    cluster = [];
+    clusterEnd = -1;
+  };
+
+  for (const seg of segs) {
+    if (cluster.length && seg.startMin >= clusterEnd) flush();
+    cluster.push(seg);
+    clusterEnd = Math.max(clusterEnd, seg.endMin);
+  }
+  flush();
+  return result;
+}
+
 /**
  * Build the 6x7 matrix (42 days) covering the month of `date`, starting on
  * Monday. Returns a flat array of Date objects.


### PR DESCRIPTION
## Calendar week & day views

Adds **Month / Week / Day** views to the calendar. Until now it was month-only; week and day give a time-grid (hour-by-hour) layout that's much better for seeing where the day actually sits.

This is **frontend-only** — `get-calendar` already accepts any range and already expands recurring events, so no backend change was needed.

### What's new

- A **view switcher** (Month / Week / Day) with per-view navigation (prev/next move by month/week/day) and an adapted title (e.g. "July 2026", "Mar 2 – Mar 8", "Wednesday, March 4").
- **Week and day** render a 24-hour time grid (`CalendarTimeGrid`): timed events are positioned by their start/end, **overlapping events are packed into side-by-side columns**, all-day / full-day events sit in a strip on top, each day header shows the **tracked-time badge**, and clicking an empty slot creates an event at that time (snapped to 30 min). Recurring occurrences keep the `↻` marker; the grid opens scrolled to 07:00.
- The **month view** is unchanged.