### PR TITLE
Bot today and more

### DIFF
--- a/ticktask/services.py
+++ b/ticktask/services.py
@@ -157,33 +157,79 @@ def clock_out(user, entry_id: int) -> TimeEntry:
 
 def recent_time_entries(user, limit: int = 10):
     """
-    Returns the user's most recent time entries (newest first) on live
-    tasks/subtasks, with their subtask and task preloaded.
+    Returns ``(entries, total)``: the user's most recent time entries (newest
+    first, capped at ``limit``) on live tasks/subtasks with their subtask and
+    task preloaded, plus the total number available (for a "and N more" hint).
     """
-    return list(
+    qs = (
         TimeEntry.objects.select_related("subtask__task")  # pylint: disable=no-member
         .filter(
             subtask__task__user=user,
             subtask__deleted_at__isnull=True,
             subtask__task__deleted_at__isnull=True,
         )
-        .order_by("-clock_in")[:limit]
+        .order_by("-clock_in")
     )
+    return list(qs[:limit]), qs.count()
 
 
 def upcoming_events(user, days: int = 7, limit: int = 10):
     """
-    Returns the user's upcoming calendar events starting within the next
-    ``days`` days (or already ongoing), ordered by start.
+    Returns ``(events, total)``: the user's upcoming calendar events starting
+    within the next ``days`` days (or already ongoing), ordered by start and
+    capped at ``limit``, plus the total number available.
     """
     now = timezone.now()
     # Future events, plus ones already ongoing (started but not yet ended).
     not_over_yet = Q(start__gte=now) | Q(end__gte=now)
-    return list(
-        CalendarEvent.objects.filter(  # pylint: disable=no-member
-            not_over_yet, user=user, start__lte=now + timedelta(days=days)
-        ).order_by("start")[:limit]
+    qs = CalendarEvent.objects.filter(  # pylint: disable=no-member
+        not_over_yet, user=user, start__lte=now + timedelta(days=days)
+    ).order_by("start")
+    return list(qs[:limit]), qs.count()
+
+
+def tracked_total(user, start, end):
+    """Total tracked time (closed entries) on live tasks within ``[start, end]``."""
+    total = timedelta()
+    rows = TimeEntry.objects.filter(  # pylint: disable=no-member
+        subtask__task__user=user,
+        clock_out__isnull=False,
+        clock_in__gte=start,
+        clock_in__lte=end,
+        subtask__deleted_at__isnull=True,
+        subtask__task__deleted_at__isnull=True,
+    ).values("clock_in", "clock_out")
+    for row in rows:
+        total += row["clock_out"] - row["clock_in"]
+    return total
+
+
+def events_in_window(user, start, end):
+    """
+    Returns ``(event, occurrence_start)`` pairs whose occurrence falls within
+    ``[start, end]`` (recurring events expanded), sorted by occurrence start.
+    """
+    candidates = CalendarEvent.objects.filter(  # pylint: disable=no-member
+        user=user, start__lte=end
+    ).filter(
+        Q(recurrence="")
+        | Q(recurrence_until__isnull=True)
+        | Q(recurrence_until__gte=start)
     )
+
+    pairs = []
+    for event in candidates:
+        if not event.recurrence:
+            event_end = event.end or event.start
+            if event.start <= end and event_end >= start:
+                pairs.append((event, event.start))
+        else:
+            for occ in occurrences_between(
+                event.start, event.recurrence, event.recurrence_until, start, end
+            ):
+                pairs.append((event, occ))
+    pairs.sort(key=lambda pair: pair[1])
+    return pairs
 
 
 # --------------------------------------------------------------------------- #

--- a/ticktask/telegram.py
+++ b/ticktask/telegram.py
@@ -47,6 +47,7 @@ ADMIN_PREFIX = "🛡️ ADMIN"
 BOT_COMMANDS = [
     ("clockin", "Start tracking time on a subtask"),
     ("clockout", "Stop the current time entry"),
+    ("today", "Today's tracked time and events"),
     ("tasks", "Show your recent activity"),
     ("events", "Show your upcoming events"),
     ("newtask", "Create a new task"),
@@ -241,6 +242,7 @@ def _handle_command(user, chat_id, text: str) -> None:
     cmd = word.split("@")[0]  # tolerate /clockin@TickTaskBot in groups
     handler = {
         "help": lambda u, c: _send_help(c),
+        "today": _cmd_today,
         "tasks": _cmd_recent,
         "recent": _cmd_recent,
         "events": _cmd_events,
@@ -264,9 +266,44 @@ def _send_help(chat_id) -> None:
     _safe_send(chat_id, "\n".join(lines))
 
 
+def _more_footer(count: int) -> str:
+    """Footer line shown when a list was capped, pointing back to the app."""
+    return f"…and {count} more — open TickTask to see the rest."
+
+
+def _cmd_today(user, chat_id) -> None:
+    """``/today`` — today's tracked total, the open entry, and today's events."""
+    zone = _user_zone(user)
+    now_local = timezone.now().astimezone(zone)
+    day_start = now_local.replace(hour=0, minute=0, second=0, microsecond=0)
+    day_end = day_start + timedelta(days=1)
+
+    total = services.tracked_total(user, day_start, day_end)
+    open_entry = services.get_open_entry(user)
+    events = services.events_in_window(user, day_start, day_end)
+
+    lines = [f"📊 Today — {now_local.strftime('%Y-%m-%d')}"]
+    lines.append(f"⏱ Tracked: {_format_duration(total)}")
+    if open_entry is not None:
+        lines.append(f"🟢 Clocked in on {_entry_label(open_entry)}")
+
+    if events:
+        lines.append("")
+        lines.append("📅 Events today:")
+        for event, occurrence in events[:LIST_LIMIT]:
+            when = "all day" if event.all_day else occurrence.astimezone(zone).strftime("%H:%M")
+            lines.append(f"• {event.title} — {when}")
+        if len(events) > LIST_LIMIT:
+            lines.append(_more_footer(len(events) - LIST_LIMIT))
+    else:
+        lines.append("")
+        lines.append("No events today.")
+    _safe_send(chat_id, "\n".join(lines))
+
+
 def _cmd_recent(user, chat_id) -> None:
     """``/tasks`` — recent activity and the current open entry, if any."""
-    entries = services.recent_time_entries(user, limit=LIST_LIMIT)
+    entries, total = services.recent_time_entries(user, limit=LIST_LIMIT)
     if not entries:
         _safe_send(chat_id, "No time tracked yet. Use /clockin to get started.")
         return
@@ -278,12 +315,14 @@ def _cmd_recent(user, chat_id) -> None:
         else:
             duration = _format_duration(entry.clock_out - entry.clock_in)
             lines.append(f"• {label} — {duration}")
+    if total > len(entries):
+        lines.append(_more_footer(total - len(entries)))
     _safe_send(chat_id, "\n".join(lines))
 
 
 def _cmd_events(user, chat_id) -> None:
     """``/events`` — upcoming calendar events for the next few days."""
-    events = services.upcoming_events(user, days=7, limit=LIST_LIMIT)
+    events, total = services.upcoming_events(user, days=7, limit=LIST_LIMIT)
     if not events:
         _safe_send(chat_id, "No upcoming events in the next 7 days.")
         return
@@ -291,6 +330,8 @@ def _cmd_events(user, chat_id) -> None:
     lines = ["📅 Upcoming events:"]
     for event in events:
         lines.append(f"• {event.title} — {_format_event_when(event, zone)}")
+    if total > len(events):
+        lines.append(_more_footer(total - len(events)))
     _safe_send(chat_id, "\n".join(lines))
 
 

--- a/ticktask/tests/test_telegram_bot.py
+++ b/ticktask/tests/test_telegram_bot.py
@@ -207,6 +207,66 @@ def test_events_empty_state(stub_telegram_http):
 
 
 @pytest.mark.django_db
+def test_tasks_shows_and_n_more_footer(stub_telegram_http):
+    """When more than the cap exist, a '…and N more' footer is appended."""
+    user = linked_user()
+    task = Task.objects.create(user=user, name="Proj")  # pylint: disable=no-member
+    sub = SubTask.objects.create(task=task, name="Code", description="")  # pylint: disable=no-member
+    now = timezone.now()
+    for i in range(13):  # cap is 10
+        TimeEntry.objects.create(  # pylint: disable=no-member
+            subtask=sub,
+            clock_in=now - timedelta(hours=i + 1),
+            clock_out=now - timedelta(hours=i, minutes=30),
+        )
+
+    telegram.process_update(command("/tasks"))
+
+    text = "\n".join(sent_texts(stub_telegram_http))
+    assert "…and 3 more" in text
+
+
+@pytest.mark.django_db
+def test_today_reports_tracked_total_and_events(stub_telegram_http):
+    """/today shows today's tracked time, the open entry, and today's events."""
+    user = linked_user()
+    task = Task.objects.create(user=user, name="Proj")  # pylint: disable=no-member
+    sub = SubTask.objects.create(task=task, name="Code", description="")  # pylint: disable=no-member
+    now = timezone.now()
+    # 90 min tracked earlier today.
+    TimeEntry.objects.create(  # pylint: disable=no-member
+        subtask=sub,
+        clock_in=now.replace(hour=0, minute=0, second=0, microsecond=0)
+        + timedelta(hours=1),
+        clock_out=now.replace(hour=0, minute=0, second=0, microsecond=0)
+        + timedelta(hours=2, minutes=30),
+    )
+    CalendarEvent.objects.create(  # pylint: disable=no-member
+        user=user,
+        title="Sync",
+        start=now.replace(hour=0, minute=0, second=0, microsecond=0)
+        + timedelta(hours=15),
+    )
+
+    telegram.process_update(command("/today"))
+
+    text = "\n".join(sent_texts(stub_telegram_http))
+    assert "Today" in text
+    assert "1h 30m" in text
+    assert "Sync" in text
+
+
+@pytest.mark.django_db
+def test_today_empty(stub_telegram_http):
+    """With nothing tracked or scheduled, /today still reports cleanly."""
+    linked_user()
+    telegram.process_update(command("/today"))
+    text = "\n".join(sent_texts(stub_telegram_http))
+    assert "Tracked: 0m" in text
+    assert "No events today" in text
+
+
+@pytest.mark.django_db
 def test_events_formatted_in_user_timezone(stub_telegram_http):
     """Event times are shown in the user's configured timezone, not UTC."""
     user = linked_user()


### PR DESCRIPTION
## Bot: /today and long-list footers

Two small Telegram bot improvements that round off the command set.

### What's new

- **`/today`**: reports today's tracked total, the currently open entry (if any), and today's events — all in the user's timezone. Today's events include occurrences of recurring events, so a weekly event shows on the days it actually falls on.
- **"…and N more" footer**: `/tasks`, `/events` and `/today`'s event list cap at 10 rows; when there are more, they now append `…and N more — open TickTask to see the rest.` instead of silently truncating.

### How it's built

- New services: `tracked_total(user, start, end)` (closed time tracked within a window) and `events_in_window(user, start, end)` (event/occurrence pairs in a window, with recurring events expanded via the existing `occurrences_between`).
- `recent_time_entries` and `upcoming_events` now return `(items, total)` so the bot knows the exact overflow count for the footer.
- `/today` is registered in the command menu (`setMyCommands`) and the dispatcher. Bot-only change — no model change, no migration.