### PR TITLE
Show the username in the sidebar instead of 'My account'

### DIFF
--- a/ticktask/server/routes/auth.py
+++ b/ticktask/server/routes/auth.py
@@ -34,6 +34,10 @@ def _issue_session(request, user) -> dict:
     straight away.
     """
     refresh = RefreshToken.for_user(user)
+    # Carry the username in the token so the frontend (which only has the decoded
+    # JWT, not a user endpoint) can show it. Claims set on the refresh token are
+    # copied onto the access token derived from it.
+    refresh["username"] = user.username
     UserLoginRecord.objects.create(  # pylint: disable=no-member
         user=user,
         ip_address=request.META.get("REMOTE_ADDR", ""),

--- a/ticktask/tests/test_auth.py
+++ b/ticktask/tests/test_auth.py
@@ -7,6 +7,7 @@ shared service activates the account so the user can log in.
 
 import json
 
+import jwt
 import pytest
 from django.test import Client
 from django.contrib.auth.models import User
@@ -134,6 +135,18 @@ def test_approved_user_can_log_in():
     resp = post(LOGIN, {"username": "frank", "password": GOOD_PASSWORD})
     assert resp.status_code == 200
     assert resp.json()["access"]
+
+
+@pytest.mark.django_db
+def test_access_token_carries_username_claim():
+    """The access token embeds the username so the frontend can display it."""
+    post(REGISTER, {"username": "ivy", "password": GOOD_PASSWORD})
+    services.approve_access(User.objects.get(username="ivy").access_request)  # pylint: disable=no-member
+
+    resp = post(LOGIN, {"username": "ivy", "password": GOOD_PASSWORD})
+    assert resp.status_code == 200
+    claims = jwt.decode(resp.json()["access"], options={"verify_signature": False})
+    assert claims["username"] == "ivy"
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## What & why

The sidebar account widget showed **"My account"** instead of the signed-in user's name. The frontend only has the decoded JWT to display the user, but the issued token carried just `user_id`, so `LeftMenu`'s `displayName` always hit its fallback.

## Change

Embed the username as a claim on the token in `_issue_session` (`ticktask/server/routes/auth.py`). The claim is set on the refresh token, so it is copied onto the derived access token and preserved across `/auth/refresh` calls. No migration and no frontend change — `LeftMenu` already reads `auth.user.value?.username`.