### PR TITLE
Enrich the dashboard charts with interactivity and new views

### DIFF
--- a/gui/components/dashboard/Donut.vue
+++ b/gui/components/dashboard/Donut.vue
@@ -1,0 +1,81 @@
+<template>
+  <div>
+    <div class="flex items-center justify-center">
+      <div class="relative">
+        <svg
+          :viewBox="`0 0 ${SIZE} ${SIZE}`"
+          class="h-40 w-40"
+          role="img"
+          aria-label="Share of tracked time by task">
+          <!-- Track -->
+          <circle
+            :cx="C"
+            :cy="C"
+            :r="R"
+            fill="none"
+            class="stroke-border"
+            :stroke-width="THICKNESS" />
+          <!-- One arc per task -->
+          <circle
+            v-for="seg in donut.segments"
+            :key="seg.taskId"
+            :cx="C"
+            :cy="C"
+            :r="R"
+            fill="none"
+            :stroke="seg.color"
+            :stroke-width="THICKNESS"
+            :stroke-dasharray="`${seg.fraction * CIRC} ${CIRC}`"
+            :transform="`rotate(${-90 + seg.offset * 360} ${C} ${C})`">
+            <title>{{ seg.name }} · {{ formatHours(seg.hours) }} ({{ seg.percent }}%)</title>
+          </circle>
+        </svg>
+        <div
+          class="pointer-events-none absolute inset-0 flex flex-col items-center justify-center">
+          <span class="text-lg font-bold tracking-tight">{{
+            formatHours(donut.total)
+          }}</span>
+          <span class="text-[11px] text-muted-foreground">tracked</span>
+        </div>
+      </div>
+    </div>
+
+    <div v-if="donut.segments.length" class="mt-4 space-y-1.5">
+      <div
+        v-for="seg in donut.segments"
+        :key="seg.taskId"
+        class="flex items-center gap-2 text-sm">
+        <span
+          class="size-2.5 shrink-0 rounded-full"
+          :style="{ backgroundColor: seg.color }"></span>
+        <span
+          class="truncate"
+          :class="seg.deleted ? 'text-muted-foreground line-through' : ''"
+          >{{ seg.name }}</span
+        >
+        <span class="ml-auto shrink-0 tabular-nums text-muted-foreground">
+          {{ seg.percent }}% · {{ formatHours(seg.hours) }}
+        </span>
+      </div>
+    </div>
+    <p v-else class="mt-4 text-center text-sm text-muted-foreground">
+      No tracked time in this range.
+    </p>
+  </div>
+</template>
+
+<script setup>
+  import { computed } from "vue";
+
+  const props = defineProps({
+    tasks: { type: Array, default: () => [] },
+  });
+
+  const SIZE = 120;
+  const C = SIZE / 2;
+  const THICKNESS = 18;
+  const R = C - THICKNESS / 2;
+  const CIRC = 2 * Math.PI * R;
+
+  const donut = computed(() => donutSegments(props.tasks));
+</script>

--- a/gui/components/dashboard/Heatmap.vue
+++ b/gui/components/dashboard/Heatmap.vue
@@ -1,0 +1,87 @@
+<template>
+  <div>
+    <div class="overflow-x-auto pb-1">
+      <div class="inline-flex flex-col gap-1">
+        <!-- Month labels -->
+        <div class="flex gap-1 pl-8">
+          <div
+            v-for="(col, w) in grid.columns"
+            :key="`m-${w}`"
+            class="w-3 text-[10px] text-muted-foreground">
+            {{ monthLabelByWeek[w] || "" }}
+          </div>
+        </div>
+
+        <div class="flex gap-1">
+          <!-- Weekday labels -->
+          <div class="flex w-7 flex-col gap-1 pr-1 text-[9px] text-muted-foreground">
+            <span
+              v-for="(label, d) in WEEKDAYS"
+              :key="`wd-${d}`"
+              class="flex h-3 items-center">
+              {{ label }}
+            </span>
+          </div>
+
+          <!-- Week columns -->
+          <div
+            v-for="(col, w) in grid.columns"
+            :key="`c-${w}`"
+            class="flex flex-col gap-1">
+            <div
+              v-for="cell in col"
+              :key="cell.date"
+              class="size-3 rounded-sm"
+              :class="cell.future ? 'opacity-0' : LEVELS[cell.level]"
+              :title="
+                cell.future ? '' : `${cell.date}: ${formatHours(cell.hours)}`
+              "></div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Legend -->
+    <div
+      class="mt-3 flex items-center justify-end gap-1.5 text-[11px] text-muted-foreground">
+      <span>Less</span>
+      <span
+        v-for="(cls, level) in LEVELS"
+        :key="`lg-${level}`"
+        class="size-3 rounded-sm"
+        :class="cls"></span>
+      <span>More</span>
+    </div>
+  </div>
+</template>
+
+<script setup>
+  import { computed } from "vue";
+
+  const props = defineProps({
+    buckets: { type: Array, default: () => [] },
+    weeks: { type: Number, default: 53 },
+  });
+
+  // Monday-started, matching the backend's week bucketing; only alternate rows
+  // are labelled to keep the axis uncluttered.
+  const WEEKDAYS = ["Mon", "", "Wed", "", "Fri", "", ""];
+
+  const LEVELS = [
+    "bg-border/60",
+    "bg-primary/25",
+    "bg-primary/45",
+    "bg-primary/70",
+    "bg-primary",
+  ];
+
+  const grid = computed(() =>
+    heatmapGrid(props.buckets, { weeks: props.weeks }),
+  );
+
+  const monthLabelByWeek = computed(() => {
+    const map = {};
+    for (const label of grid.value.monthLabels) map[label.week] = label.text;
+    return map;
+  });
+</script>

--- a/gui/components/dashboard/StackedBar.vue
+++ b/gui/components/dashboard/StackedBar.vue
@@ -1,0 +1,154 @@
+<template>
+  <div>
+    <div class="relative">
+      <svg
+        :viewBox="`0 0 ${W} ${H}`"
+        class="h-auto w-full"
+        preserveAspectRatio="xMidYMid meet"
+        role="img"
+        :aria-label="`Tracked hours per ${bucket}, stacked by task`">
+        <!-- Gridlines + y-axis labels -->
+        <g>
+          <line
+            v-for="tick in geometry.yTicks"
+            :key="`grid-${tick.value}`"
+            :x1="PAD.left"
+            :x2="W - PAD.right"
+            :y1="tick.y"
+            :y2="tick.y"
+            class="stroke-border"
+            stroke-width="1" />
+          <text
+            v-for="tick in geometry.yTicks"
+            :key="`ylabel-${tick.value}`"
+            :x="PAD.left - 8"
+            :y="tick.y + 3"
+            text-anchor="end"
+            class="fill-muted-foreground text-[10px]">
+            {{ tick.value }}
+          </text>
+        </g>
+
+        <!-- Stacked bars -->
+        <g v-for="bar in geometry.bars" :key="`bar-${bar.i}`">
+          <rect
+            v-for="seg in bar.rects"
+            :key="`${bar.i}-${seg.taskId}`"
+            :x="bar.x"
+            :y="seg.y"
+            :width="bar.width"
+            :height="seg.height"
+            :fill="seg.color">
+            <title>{{ seg.name }} · {{ formatHours(seg.hours) }}</title>
+          </rect>
+        </g>
+
+        <!-- X-axis labels -->
+        <text
+          v-for="label in geometry.xLabels"
+          :key="`xlabel-${label.period_start}`"
+          :x="label.x"
+          :y="H - 8"
+          text-anchor="middle"
+          class="fill-muted-foreground text-[10px]">
+          {{ label.text }}
+        </text>
+      </svg>
+
+      <div
+        v-if="geometry.message"
+        class="pointer-events-none absolute inset-0 flex items-center justify-center">
+        <p class="text-sm text-muted-foreground">{{ geometry.message }}</p>
+      </div>
+    </div>
+
+    <!-- Legend -->
+    <div v-if="legend.length" class="mt-3 flex flex-wrap gap-x-4 gap-y-1.5">
+      <span
+        v-for="entry in legend"
+        :key="entry.taskId"
+        class="flex items-center gap-1.5 text-xs font-medium"
+        :class="entry.deleted ? 'text-muted-foreground' : 'text-foreground'">
+        <span
+          class="size-2.5 rounded-full"
+          :style="{ backgroundColor: entry.color }"></span>
+        <span :class="{ 'line-through': entry.deleted }">{{ entry.name }}</span>
+      </span>
+    </div>
+  </div>
+</template>
+
+<script setup>
+  import { computed } from "vue";
+
+  const props = defineProps({
+    buckets: { type: Array, default: () => [] },
+    tasks: { type: Array, default: () => [] },
+    bucket: { type: String, default: "day" },
+  });
+
+  const W = 720;
+  const H = 240;
+  const PAD = { top: 16, right: 16, bottom: 28, left: 36 };
+  const innerW = W - PAD.left - PAD.right;
+  const innerH = H - PAD.top - PAD.bottom;
+  const TICKS = 4;
+
+  // Only tasks with tracked time in the range make it into the legend/stacks.
+  const legend = computed(() => {
+    const withTime = new Set();
+    props.tasks.forEach((task) => {
+      if ((task.series || []).some((h) => h > 0)) withTime.add(task.task_id);
+    });
+    return props.tasks
+      .map((task, index) => ({
+        taskId: task.task_id,
+        name: task.task_name,
+        deleted: task.deleted,
+        color: chartColor(index),
+      }))
+      .filter((entry) => withTime.has(entry.taskId));
+  });
+
+  const geometry = computed(() => {
+    const stacks = stackedBuckets(props.buckets, props.tasks);
+    const n = stacks.length;
+    const niceMax = niceCeil(Math.max(0, ...stacks.map((s) => s.total)));
+
+    const band = n ? innerW / n : innerW;
+    const barWidth = Math.max(band * 0.7, 1);
+    const xAt = (i) => PAD.left + i * band + (band - barWidth) / 2;
+    const yAt = (h) => PAD.top + innerH - (h / niceMax) * innerH;
+
+    const bars = stacks.map((stack, i) => {
+      let acc = 0;
+      const rects = stack.segments.map((seg) => {
+        const y = yAt(acc + seg.hours);
+        const height = (seg.hours / niceMax) * innerH;
+        acc += seg.hours;
+        return { ...seg, y, height };
+      });
+      return { i, x: xAt(i), width: barWidth, rects };
+    });
+
+    const yTicks = Array.from({ length: TICKS + 1 }, (_, k) => {
+      const value = (niceMax / TICKS) * k;
+      return { value: Math.round(value * 10) / 10, y: yAt(value) };
+    });
+
+    const labelEvery = Math.max(1, Math.ceil(n / 6));
+    const xLabels = stacks
+      .map((stack, i) => ({
+        x: xAt(i) + barWidth / 2,
+        period_start: stack.period_start,
+        text: formatBucketLabel(stack.period_start, props.bucket),
+      }))
+      .filter((_, i) => i % labelEvery === 0 || i === n - 1);
+
+    const message = stacks.some((s) => s.total > 0)
+      ? ""
+      : "No tracked time in this range.";
+
+    return { bars, yTicks, xLabels, message };
+  });
+</script>

--- a/gui/components/dashboard/TrendChart.vue
+++ b/gui/components/dashboard/TrendChart.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <div class="relative">
+    <div class="relative" @mouseleave="activeIndex = null">
       <svg
         :viewBox="`0 0 ${W} ${H}`"
         class="h-auto w-full"
@@ -29,6 +29,17 @@
           </text>
         </g>
 
+        <!-- Vertical crosshair at the hovered bucket -->
+        <line
+          v-if="activeIndex !== null"
+          :x1="geometry.xByIndex[activeIndex]"
+          :x2="geometry.xByIndex[activeIndex]"
+          :y1="PAD.top"
+          :y2="PAD.top + innerH"
+          class="stroke-muted-foreground/40"
+          stroke-width="1"
+          stroke-dasharray="3 3" />
+
         <!-- One line per visible task -->
         <g v-for="line in geometry.lines" :key="`line-${line.taskId}`">
           <path
@@ -43,12 +54,23 @@
             :key="`${line.taskId}-${point.i}`"
             :cx="point.x"
             :cy="point.y"
-            r="2.5"
+            :r="activeIndex === point.i ? 4 : 2.5"
             :fill="line.color"
             stroke-width="1.5"
-            class="stroke-card">
-            <title>{{ line.name }} · {{ point.tooltip }}</title>
-          </circle>
+            class="stroke-card" />
+          <!-- Value labels (opt-in) -->
+          <template v-if="showValues">
+            <text
+              v-for="point in line.dots"
+              :key="`val-${line.taskId}-${point.i}`"
+              :x="point.x"
+              :y="Math.max(point.y - 7, 10)"
+              text-anchor="middle"
+              :fill="line.color"
+              class="text-[9px] font-medium">
+              {{ point.label }}
+            </text>
+          </template>
         </g>
 
         <!-- X-axis labels -->
@@ -61,7 +83,42 @@
           class="fill-muted-foreground text-[10px]">
           {{ label.text }}
         </text>
+
+        <!-- Transparent hover bands, one per bucket, to drive the tooltip -->
+        <rect
+          v-for="band in geometry.hoverBands"
+          :key="`band-${band.i}`"
+          :x="band.x"
+          :y="PAD.top"
+          :width="band.width"
+          :height="innerH"
+          fill="transparent"
+          class="cursor-crosshair"
+          @mouseenter="activeIndex = band.i" />
       </svg>
+
+      <!-- Floating tooltip -->
+      <div
+        v-if="tooltip"
+        class="pointer-events-none absolute top-2 z-20 min-w-[9rem] rounded-xl border border-border bg-card/95 p-2.5 text-xs shadow-soft backdrop-blur-sm"
+        :style="tooltipStyle">
+        <p class="mb-1.5 font-semibold text-foreground">{{ tooltip.label }}</p>
+        <ul v-if="tooltip.rows.length" class="space-y-1">
+          <li
+            v-for="row in tooltip.rows"
+            :key="row.taskId"
+            class="flex items-center gap-2">
+            <span
+              class="size-2 shrink-0 rounded-full"
+              :style="{ backgroundColor: row.color }"></span>
+            <span class="truncate text-muted-foreground">{{ row.name }}</span>
+            <span class="ml-auto font-medium tabular-nums text-foreground">{{
+              formatHours(row.hours)
+            }}</span>
+          </li>
+        </ul>
+        <p v-else class="text-muted-foreground">No time tracked.</p>
+      </div>
 
       <div
         v-if="geometry.message"
@@ -70,39 +127,55 @@
       </div>
     </div>
 
-    <!-- Legend: click to show/hide a task's line -->
-    <div v-if="tasks.length" class="mt-3 flex flex-wrap gap-x-4 gap-y-1.5">
+    <div
+      v-if="tasks.length"
+      class="mt-3 flex flex-wrap items-center justify-between gap-3">
+      <!-- Legend: click to show/hide a task's line -->
+      <div class="flex flex-wrap gap-x-4 gap-y-1.5">
+        <button
+          v-for="entry in legend"
+          :key="entry.taskId"
+          class="flex items-center gap-1.5 text-xs font-medium transition-colors"
+          :class="entry.hidden ? 'text-muted-foreground/60' : 'text-foreground'"
+          :title="entry.hidden ? 'Show this task' : 'Hide this task'"
+          @click="toggle(entry.taskId)">
+          <span
+            class="size-2.5 rounded-full transition-opacity"
+            :style="{
+              backgroundColor: entry.color,
+              opacity: entry.hidden ? 0.3 : 1,
+            }"></span>
+          <span :class="{ 'line-through': entry.hidden || entry.deleted }">{{
+            entry.name
+          }}</span>
+          <span
+            v-if="entry.deleted"
+            class="text-[10px] uppercase tracking-wide text-muted-foreground"
+            >(deleted)</span
+          >
+          <span class="text-muted-foreground">{{
+            formatHours(entry.hours)
+          }}</span>
+        </button>
+      </div>
+
+      <!-- Toggle the on-point value labels -->
       <button
-        v-for="entry in legend"
-        :key="entry.taskId"
-        class="flex items-center gap-1.5 text-xs font-medium transition-colors"
-        :class="entry.hidden ? 'text-muted-foreground/60' : 'text-foreground'"
-        :title="entry.hidden ? 'Show this task' : 'Hide this task'"
-        @click="toggle(entry.taskId)">
-        <span
-          class="size-2.5 rounded-full transition-opacity"
-          :style="{
-            backgroundColor: entry.color,
-            opacity: entry.hidden ? 0.3 : 1,
-          }"></span>
-        <span :class="{ 'line-through': entry.hidden || entry.deleted }">{{
-          entry.name
-        }}</span>
-        <span
-          v-if="entry.deleted"
-          class="text-[10px] uppercase tracking-wide text-muted-foreground"
-          >(deleted)</span
-        >
-        <span class="text-muted-foreground">{{
-          formatHours(entry.hours)
-        }}</span>
+        class="flex shrink-0 items-center gap-1.5 text-xs font-medium transition-colors"
+        :class="showValues ? 'text-primary' : 'text-muted-foreground hover:text-foreground'"
+        :title="showValues ? 'Hide values' : 'Show values'"
+        @click="showValues = !showValues">
+        <Icon
+          :name="showValues ? 'lucide:eye' : 'lucide:eye-off'"
+          class="size-3.5" />
+        Values
       </button>
     </div>
   </div>
 </template>
 
 <script setup>
-  import { computed, reactive } from "vue";
+  import { computed, reactive, ref } from "vue";
 
   const props = defineProps({
     buckets: { type: Array, default: () => [] },
@@ -118,6 +191,8 @@
   const TICKS = 4;
 
   const hidden = reactive(new Set());
+  const activeIndex = ref(null);
+  const showValues = ref(false);
 
   function toggle(taskId) {
     if (hidden.has(taskId)) hidden.delete(taskId);
@@ -151,13 +226,15 @@
       n <= 1 ? PAD.left + innerW / 2 : PAD.left + (i / (n - 1)) * innerW;
     const yAt = (h) => PAD.top + innerH - (h / niceMax) * innerH;
 
+    const xByIndex = props.buckets.map((_, i) => xAt(i));
+
     const lines = visible.map(({ task, color }) => {
       const points = (task.series || []).map((hours, i) => ({
         i,
         x: xAt(i),
         y: yAt(hours),
         hours,
-        tooltip: `${labelAt(i)}: ${formatHours(hours)}`,
+        label: formatHours(hours),
       }));
       return {
         taskId: task.task_id,
@@ -166,8 +243,18 @@
         path: points
           .map((p, i) => `${i ? "L" : "M"}${p.x.toFixed(1)} ${p.y.toFixed(1)}`)
           .join(" "),
+        points,
         dots: points.filter((p) => p.hours > 0),
       };
+    });
+
+    // A full-height band around each bucket so hovering anywhere in the column
+    // (not just on a dot) reveals that bucket's values.
+    const hoverBands = xByIndex.map((x, i) => {
+      const left = i === 0 ? PAD.left : (xByIndex[i - 1] + x) / 2;
+      const right =
+        i === n - 1 ? W - PAD.right : (xByIndex[i + 1] + x) / 2;
+      return { i, x: left, width: Math.max(right - left, 0) };
     });
 
     const yTicks = Array.from({ length: TICKS + 1 }, (_, k) => {
@@ -188,7 +275,36 @@
     if (!props.tasks.length) message = "No tracked time in this range.";
     else if (!visible.length) message = "All tasks hidden.";
 
-    return { lines, yTicks, xLabels, message };
+    return { lines, yTicks, xLabels, message, xByIndex, hoverBands };
+  });
+
+  // The values at the hovered bucket, biggest first, for the floating tooltip.
+  const tooltip = computed(() => {
+    if (activeIndex.value === null) return null;
+    const i = activeIndex.value;
+    const b = props.buckets[i];
+    if (!b) return null;
+    const rows = geometry.value.lines
+      .map((line) => ({
+        taskId: line.taskId,
+        name: line.name,
+        color: line.color,
+        hours: line.points[i] ? line.points[i].hours : 0,
+      }))
+      .filter((row) => row.hours > 0)
+      .sort((a, b) => b.hours - a.hours);
+    return { label: labelAt(i), rows };
+  });
+
+  // Anchor the tooltip to the hovered column, nudging it inward near the edges
+  // so it never spills out of the chart.
+  const tooltipStyle = computed(() => {
+    if (activeIndex.value === null) return {};
+    const pct = (geometry.value.xByIndex[activeIndex.value] / W) * 100;
+    let shift = "-50%";
+    if (pct < 20) shift = "0%";
+    else if (pct > 80) shift = "-100%";
+    return { left: `${pct}%`, transform: `translateX(${shift})` };
   });
 
   function labelAt(i) {

--- a/gui/pages/dashboard.vue
+++ b/gui/pages/dashboard.vue
@@ -38,21 +38,68 @@
           <p class="mt-0.5 text-sm text-muted-foreground">{{ rangeLabel }}</p>
         </template>
         <template #actions>
-          <div class="inline-flex rounded-xl border border-border p-0.5">
-            <button
-              v-for="option in BUCKET_OPTIONS"
-              :key="option.value"
-              class="rounded-lg px-3 py-1 text-sm font-medium transition-colors"
-              :class="
-                bucket === option.value
-                  ? 'bg-primary text-primary-foreground shadow-soft'
-                  : 'text-muted-foreground hover:text-foreground'
-              "
-              @click="bucket = option.value">
-              {{ option.label }}
-            </button>
+          <div class="flex flex-wrap items-center justify-end gap-2">
+            <div class="inline-flex rounded-xl border border-border p-0.5">
+              <button
+                v-for="option in RANGE_OPTIONS"
+                :key="option.value"
+                class="rounded-lg px-3 py-1 text-sm font-medium transition-colors"
+                :class="
+                  range === option.value
+                    ? 'bg-primary text-primary-foreground shadow-soft'
+                    : 'text-muted-foreground hover:text-foreground'
+                "
+                @click="range = option.value">
+                {{ option.label }}
+              </button>
+              <button
+                class="rounded-lg px-3 py-1 text-sm font-medium transition-colors"
+                :class="
+                  range === 'custom'
+                    ? 'bg-primary text-primary-foreground shadow-soft'
+                    : 'text-muted-foreground hover:text-foreground'
+                "
+                @click="selectCustomRange">
+                Custom
+              </button>
+            </div>
+            <div class="inline-flex rounded-xl border border-border p-0.5">
+              <button
+                v-for="option in BUCKET_OPTIONS"
+                :key="option.value"
+                class="rounded-lg px-3 py-1 text-sm font-medium transition-colors"
+                :class="
+                  bucket === option.value
+                    ? 'bg-primary text-primary-foreground shadow-soft'
+                    : 'text-muted-foreground hover:text-foreground'
+                "
+                @click="bucket = option.value">
+                {{ option.label }}
+              </button>
+            </div>
           </div>
         </template>
+
+        <div
+          v-if="range === 'custom'"
+          class="mb-4 flex flex-wrap items-center gap-2 text-sm">
+          <label class="flex items-center gap-1.5 text-muted-foreground">
+            From
+            <input
+              v-model="customStart"
+              type="date"
+              :max="customEnd || undefined"
+              class="rounded-lg border border-border bg-background px-2 py-1 text-foreground" />
+          </label>
+          <label class="flex items-center gap-1.5 text-muted-foreground">
+            To
+            <input
+              v-model="customEnd"
+              type="date"
+              :min="customStart || undefined"
+              class="rounded-lg border border-border bg-background px-2 py-1 text-foreground" />
+          </label>
+        </div>
 
         <div class="relative min-h-[240px]">
           <div
@@ -86,6 +133,55 @@
       </UiCard>
     </div>
 
+    <!-- Composition + share -->
+    <div class="grid gap-6 lg:grid-cols-3">
+      <UiCard
+        class="lg:col-span-2"
+        title="Composition over time"
+        :subtitle="rangeLabel">
+        <div class="relative min-h-[240px]">
+          <div
+            v-if="seriesLoading"
+            class="absolute inset-0 z-10 flex items-center justify-center rounded-xl bg-card/60 backdrop-blur-sm">
+            <Icon
+              name="lucide:loader-circle"
+              class="size-6 animate-spin text-muted-foreground" />
+          </div>
+          <DashboardStackedBar
+            :buckets="series?.buckets || []"
+            :tasks="series?.by_task || []"
+            :bucket="bucket" />
+        </div>
+      </UiCard>
+
+      <UiCard title="Share by task" subtitle="In the selected range">
+        <div class="relative min-h-[240px]">
+          <div
+            v-if="seriesLoading"
+            class="absolute inset-0 z-10 flex items-center justify-center rounded-xl bg-card/60 backdrop-blur-sm">
+            <Icon
+              name="lucide:loader-circle"
+              class="size-6 animate-spin text-muted-foreground" />
+          </div>
+          <DashboardDonut :tasks="series?.by_task || []" />
+        </div>
+      </UiCard>
+    </div>
+
+    <!-- Daily activity heatmap -->
+    <UiCard title="Daily activity" subtitle="Hours tracked per day over the last year">
+      <div class="relative min-h-[160px]">
+        <div
+          v-if="heatmapLoading"
+          class="absolute inset-0 z-10 flex items-center justify-center rounded-xl bg-card/60 backdrop-blur-sm">
+          <Icon
+            name="lucide:loader-circle"
+            class="size-6 animate-spin text-muted-foreground" />
+        </div>
+        <DashboardHeatmap :buckets="heatmap?.buckets || []" />
+      </div>
+    </UiCard>
+
     <!-- Share of the last 7 days, per task -->
     <UiCard title="This week by task" subtitle="Share of time tracked in the last 7 days">
       <div class="relative min-h-[200px]">
@@ -117,12 +213,21 @@
   const toast = useToast();
 
   const bucket = ref("day");
+  const range = ref(30);
+  const customStart = ref("");
+  const customEnd = ref("");
   const includeDeleted = ref(false);
   const summary = ref(null);
   const series = ref(null);
   const seriesLoading = ref(false);
   const weekly = ref(null);
   const weeklyLoading = ref(false);
+  const heatmap = ref(null);
+  const heatmapLoading = ref(false);
+
+  // The heatmap always shows a fixed trailing year of daily data, independent
+  // of the trend chart's range/bucket selection.
+  const HEATMAP_DAYS = 53 * 7;
 
   const statCards = computed(() => {
     const s = summary.value;
@@ -183,13 +288,37 @@
     }
   }
 
+  // Resolves the current selection to a `{ start, end }` range, or null when a
+  // custom range is incomplete/invalid (nothing to load yet).
+  function currentRange() {
+    if (range.value !== "custom") return rangeForDays(range.value);
+    if (!customStart.value || !customEnd.value) return null;
+    const start = new Date(`${customStart.value}T00:00:00`);
+    const end = new Date(`${customEnd.value}T23:59:59.999`);
+    if (Number.isNaN(start.getTime()) || Number.isNaN(end.getTime())) return null;
+    if (end < start) return null;
+    return { start, end };
+  }
+
+  // Switches to a custom range, seeding the inputs from the last 30 days so
+  // they are never empty when the pickers first appear.
+  function selectCustomRange() {
+    if (!customStart.value || !customEnd.value) {
+      const { start, end } = rangeForDays(30);
+      customStart.value = toDateInput(start);
+      customEnd.value = toDateInput(end);
+    }
+    range.value = "custom";
+  }
+
   async function loadSeries() {
+    const window = currentRange();
+    if (!window) return;
     seriesLoading.value = true;
     try {
-      const { start, end } = rangeForBucket(bucket.value);
       series.value = await getTimeSeries(
-        start.toISOString(),
-        end.toISOString(),
+        window.start.toISOString(),
+        window.end.toISOString(),
         bucket.value,
         includeDeleted.value,
       );
@@ -201,11 +330,29 @@
     }
   }
 
+  async function loadHeatmap() {
+    heatmapLoading.value = true;
+    try {
+      const { start, end } = rangeForDays(HEATMAP_DAYS);
+      heatmap.value = await getTimeSeries(
+        start.toISOString(),
+        end.toISOString(),
+        "day",
+        includeDeleted.value,
+      );
+    } catch (err) {
+      console.error("Error loading dashboard heatmap:", err);
+      toast.error("Couldn't load the activity heatmap.");
+    } finally {
+      heatmapLoading.value = false;
+    }
+  }
+
   async function restoreTask(taskId) {
     try {
       await apiRestoreTask(taskId);
       toast.success("Task restored.");
-      await Promise.all([loadSummary(), loadSeries(), loadWeekly()]);
+      await Promise.all([loadSummary(), loadSeries(), loadWeekly(), loadHeatmap()]);
     } catch (err) {
       console.error("Error restoring task:", err);
       toast.error("Couldn't restore the task.");
@@ -216,16 +363,16 @@
     try {
       await apiRestoreSubtask(subtaskId);
       toast.success("Subtask restored.");
-      await Promise.all([loadSummary(), loadSeries(), loadWeekly()]);
+      await Promise.all([loadSummary(), loadSeries(), loadWeekly(), loadHeatmap()]);
     } catch (err) {
       console.error("Error restoring subtask:", err);
       toast.error("Couldn't restore the subtask.");
     }
   }
 
-  onMounted(() => Promise.all([loadSummary(), loadWeekly()]));
-  watch(bucket, loadSeries, { immediate: true });
+  onMounted(() => Promise.all([loadSummary(), loadWeekly(), loadHeatmap()]));
+  watch([bucket, range, customStart, customEnd], loadSeries, { immediate: true });
   watch(includeDeleted, () =>
-    Promise.all([loadSummary(), loadSeries(), loadWeekly()]),
+    Promise.all([loadSummary(), loadSeries(), loadWeekly(), loadHeatmap()]),
   );
 </script>

--- a/gui/tests/dashboard.test.js
+++ b/gui/tests/dashboard.test.js
@@ -2,10 +2,17 @@ import { describe, it, expect } from "vitest";
 import {
   formatHours,
   rangeForBucket,
+  rangeForDays,
+  toDateInput,
   formatBucketLabel,
   chartColor,
   niceCeil,
+  stackedBuckets,
+  donutSegments,
+  heatmapLevel,
+  heatmapGrid,
   BUCKET_OPTIONS,
+  RANGE_OPTIONS,
   CHART_COLORS,
 } from "../utils/dashboard.js";
 
@@ -58,6 +65,44 @@ describe("rangeForBucket", () => {
   });
 });
 
+describe("rangeForDays", () => {
+  it("returns a trailing window of the given length starting at midnight", () => {
+    const now = new Date(2026, 5, 22, 14, 30); // 2026-06-22 14:30 local
+    const { start, end } = rangeForDays(7, now);
+    expect(end).toEqual(now);
+    expect(start.getHours()).toBe(0);
+    expect(start.getMinutes()).toBe(0);
+    // 7 days before the 22nd of June is the 15th.
+    expect(start.getMonth()).toBe(5);
+    expect(start.getDate()).toBe(15);
+  });
+
+  it("backs rangeForBucket with each bucket's window length", () => {
+    const now = new Date(2026, 5, 22);
+    for (const option of BUCKET_OPTIONS) {
+      expect(rangeForBucket(option.value, now)).toEqual(
+        rangeForDays(option.days, now),
+      );
+    }
+  });
+
+  it("offers 7 / 30 / 90 day presets", () => {
+    expect(RANGE_OPTIONS.map((o) => o.value)).toEqual([7, 30, 90]);
+  });
+});
+
+describe("toDateInput", () => {
+  it("formats a date as a zero-padded local YYYY-MM-DD", () => {
+    expect(toDateInput(new Date(2026, 2, 9))).toBe("2026-03-09");
+  });
+
+  it("uses local components, not UTC", () => {
+    // Late-evening local time can be the next day in UTC; the label must not drift.
+    const date = new Date(2026, 0, 31, 23, 30);
+    expect(toDateInput(date)).toBe("2026-01-31");
+  });
+});
+
 describe("formatBucketLabel", () => {
   it("includes the day for day and week buckets", () => {
     expect(formatBucketLabel("2026-03-09", "day")).toMatch(/9/);
@@ -88,5 +133,111 @@ describe("niceCeil", () => {
     expect(niceCeil(7)).toBe(10);
     expect(niceCeil(12)).toBe(20);
     expect(niceCeil(1)).toBe(1);
+  });
+});
+
+describe("stackedBuckets", () => {
+  const buckets = [{ period_start: "2026-01-01" }, { period_start: "2026-01-02" }];
+  const tasks = [
+    { task_id: 1, task_name: "A", deleted: false, series: [2, 0] },
+    { task_id: 2, task_name: "B", deleted: false, series: [1, 3] },
+  ];
+
+  it("stacks per-task hours into each bucket and totals them", () => {
+    const stacks = stackedBuckets(buckets, tasks);
+    expect(stacks).toHaveLength(2);
+    expect(stacks[0].total).toBe(3);
+    expect(stacks[1].total).toBe(3);
+    expect(stacks[0].segments.map((s) => s.name)).toEqual(["A", "B"]);
+  });
+
+  it("drops zero-hour segments", () => {
+    const stacks = stackedBuckets(buckets, tasks);
+    // Task A has 0 on the second day, so only B remains there.
+    expect(stacks[1].segments.map((s) => s.name)).toEqual(["B"]);
+  });
+
+  it("keeps each task's palette color by its index", () => {
+    const stacks = stackedBuckets(buckets, tasks);
+    expect(stacks[0].segments[0].color).toBe(chartColor(0));
+    expect(stacks[0].segments[1].color).toBe(chartColor(1));
+  });
+});
+
+describe("donutSegments", () => {
+  const tasks = [
+    { task_id: 1, task_name: "A", deleted: false, hours: 1 },
+    { task_id: 2, task_name: "B", deleted: false, hours: 3 },
+    { task_id: 3, task_name: "C", deleted: false, hours: 0 },
+  ];
+
+  it("computes share, sorted biggest first, dropping empty tasks", () => {
+    const { total, segments } = donutSegments(tasks);
+    expect(total).toBe(4);
+    expect(segments.map((s) => s.name)).toEqual(["B", "A"]);
+    expect(segments[0].percent).toBe(75);
+    expect(segments[1].percent).toBe(25);
+  });
+
+  it("returns fractions and cumulative offsets that tile the ring", () => {
+    const { segments } = donutSegments(tasks);
+    expect(segments[0].offset).toBe(0);
+    expect(segments[0].fraction).toBeCloseTo(0.75);
+    expect(segments[1].offset).toBeCloseTo(0.75);
+    const last = segments[segments.length - 1];
+    expect(last.offset + last.fraction).toBeCloseTo(1);
+  });
+
+  it("keeps each task's palette color by its original index", () => {
+    const { segments } = donutSegments(tasks);
+    // B is task index 1, A is index 0, even after sorting.
+    expect(segments[0].color).toBe(chartColor(1));
+    expect(segments[1].color).toBe(chartColor(0));
+  });
+
+  it("handles an all-empty set", () => {
+    const { total, segments } = donutSegments([
+      { task_id: 1, task_name: "A", hours: 0 },
+    ]);
+    expect(total).toBe(0);
+    expect(segments).toEqual([]);
+  });
+});
+
+describe("heatmapLevel", () => {
+  it("is 0 for no hours or no max", () => {
+    expect(heatmapLevel(0, 5)).toBe(0);
+    expect(heatmapLevel(3, 0)).toBe(0);
+  });
+
+  it("buckets into 1–4 by quartile of the max", () => {
+    expect(heatmapLevel(1, 8)).toBe(1);
+    expect(heatmapLevel(4, 8)).toBe(2);
+    expect(heatmapLevel(8, 8)).toBe(4);
+  });
+});
+
+describe("heatmapGrid", () => {
+  it("lays out `weeks` Monday-started columns ending on the week of `end`", () => {
+    const end = new Date(2026, 5, 17); // Wed 2026-06-17
+    const { columns } = heatmapGrid([], { weeks: 4, end });
+    expect(columns).toHaveLength(4);
+    columns.forEach((col) => expect(col).toHaveLength(7));
+    // First cell of the last column is the Monday of end's week (2026-06-15).
+    expect(columns[3][0].date).toBe("2026-06-15");
+  });
+
+  it("maps hours onto the right day and flags future cells", () => {
+    const end = new Date(2026, 5, 17);
+    const { columns, max } = heatmapGrid(
+      [{ period_start: "2026-06-15", hours: 5 }],
+      { weeks: 1, end },
+    );
+    expect(max).toBe(5);
+    expect(columns[0][0].hours).toBe(5);
+    expect(columns[0][0].level).toBe(4);
+    // Thu–Sun of that week are after Wed the 17th → future.
+    expect(columns[0][3].future).toBe(true);
+    expect(columns[0][0].future).toBe(false);
   });
 });

--- a/gui/utils/dashboard.js
+++ b/gui/utils/dashboard.js
@@ -30,10 +30,36 @@ export const BUCKET_OPTIONS = [
 export function rangeForBucket(bucket, now = new Date()) {
   const option =
     BUCKET_OPTIONS.find((b) => b.value === bucket) || BUCKET_OPTIONS[0];
+  return rangeForDays(option.days, now);
+}
+
+/** Trailing-window presets (in days) offered by the range selector. */
+export const RANGE_OPTIONS = [
+  { value: 7, label: "7 days" },
+  { value: 30, label: "30 days" },
+  { value: 90, label: "90 days" },
+];
+
+/**
+ * Returns the `{ start, end }` Date range for a trailing window of `days` days:
+ * ending now and starting at midnight `days` days ago.
+ */
+export function rangeForDays(days, now = new Date()) {
   const start = new Date(now);
-  start.setDate(start.getDate() - option.days);
+  start.setDate(start.getDate() - days);
   start.setHours(0, 0, 0, 0);
   return { start, end: new Date(now) };
+}
+
+/**
+ * Formats a Date as a local `YYYY-MM-DD` string for a `<input type="date">`
+ * (local, so the day never drifts the way `toISOString()` can).
+ */
+export function toDateInput(date) {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, "0");
+  const d = String(date.getDate()).padStart(2, "0");
+  return `${y}-${m}-${d}`;
 }
 
 /**
@@ -76,4 +102,130 @@ export function niceCeil(value) {
   const nice =
     normalized <= 1 ? 1 : normalized <= 2 ? 2 : normalized <= 5 ? 5 : 10;
   return nice * power;
+}
+
+/**
+ * Turns the time-series `buckets` + `by_task` response into per-bucket stacks:
+ * one entry per bucket with its `total` and the `segments` (one per task with
+ * time in that bucket, keeping the task's palette index so colors line up with
+ * the trend chart). Zero-hour segments are dropped.
+ */
+export function stackedBuckets(buckets, tasks) {
+  const stacks = buckets.map((b) => ({
+    period_start: b.period_start,
+    total: 0,
+    segments: [],
+  }));
+  tasks.forEach((task, index) => {
+    const color = chartColor(index);
+    (task.series || []).forEach((hours, i) => {
+      if (!stacks[i] || hours <= 0) return;
+      stacks[i].segments.push({
+        taskId: task.task_id,
+        name: task.task_name,
+        deleted: task.deleted,
+        color,
+        hours,
+      });
+      stacks[i].total += hours;
+    });
+  });
+  return stacks;
+}
+
+/**
+ * Turns the per-task totals (`by_task`) into donut segments: each task's share
+ * of the total as a `fraction` (0–1) and cumulative `offset` (so a segment
+ * spans `[offset, offset + fraction)` of the ring), plus a rounded `percent`.
+ * Tasks with no time are dropped; the rest come biggest-first. Palette index is
+ * the task's original position, so colors match the other charts.
+ */
+export function donutSegments(tasks) {
+  const active = tasks
+    .map((task, index) => ({
+      taskId: task.task_id,
+      name: task.task_name,
+      deleted: task.deleted,
+      color: chartColor(index),
+      hours: task.hours,
+    }))
+    .filter((t) => t.hours > 0)
+    .sort((a, b) => b.hours - a.hours);
+
+  const total = active.reduce((sum, t) => sum + t.hours, 0);
+  let offset = 0;
+  const segments = active.map((t) => {
+    const fraction = total ? t.hours / total : 0;
+    const seg = {
+      ...t,
+      fraction,
+      offset,
+      percent: total ? Math.round((t.hours / total) * 1000) / 10 : 0,
+    };
+    offset += fraction;
+    return seg;
+  });
+  return { total, segments };
+}
+
+/** Maps an hours value to a heatmap intensity level (0 = none, 1–4 = quartiles). */
+export function heatmapLevel(hours, max) {
+  if (!hours || hours <= 0 || max <= 0) return 0;
+  return Math.min(4, Math.ceil((hours / max) * 4));
+}
+
+/**
+ * Builds a GitHub-style day heatmap: `weeks` Monday-started columns of 7 days
+ * ending on the week of `end`. Each cell carries its `date`, `hours`, intensity
+ * `level` and a `future` flag (days after `end`). Also returns the observed
+ * `max` and `monthLabels` (the column index where each month first appears).
+ */
+export function heatmapGrid(buckets, { weeks = 53, end = new Date() } = {}) {
+  const byDate = new Map();
+  let max = 0;
+  for (const b of buckets) {
+    byDate.set(b.period_start, b.hours);
+    if (b.hours > max) max = b.hours;
+  }
+
+  const endDay = new Date(end);
+  endDay.setHours(0, 0, 0, 0);
+  // Monday (0) … Sunday (6) index of `end`, then walk back to the first column.
+  const dow = (endDay.getDay() + 6) % 7;
+  const firstMonday = new Date(endDay);
+  firstMonday.setDate(firstMonday.getDate() - dow - (weeks - 1) * 7);
+
+  const columns = [];
+  const monthLabels = [];
+  let lastMonth = -1;
+  for (let w = 0; w < weeks; w++) {
+    const days = [];
+    for (let d = 0; d < 7; d++) {
+      const date = new Date(firstMonday);
+      date.setDate(date.getDate() + w * 7 + d);
+      const key = toDateInput(date);
+      const future = date > endDay;
+      const hours = byDate.get(key) || 0;
+      days.push({
+        date: key,
+        hours,
+        future,
+        level: future ? 0 : heatmapLevel(hours, max),
+      });
+    }
+    if (days[0]) {
+      const month = new Date(`${days[0].date}T00:00:00`).getMonth();
+      if (month !== lastMonth) {
+        lastMonth = month;
+        monthLabels.push({
+          week: w,
+          text: new Date(`${days[0].date}T00:00:00`).toLocaleDateString([], {
+            month: "short",
+          }),
+        });
+      }
+    }
+    columns.push(days);
+  }
+  return { columns, max, monthLabels };
 }


### PR DESCRIPTION
# Enrich the dashboard charts with interactivity and new views

The dashboard's charts were static: the trend line derived its time window from the bucket granularity, tooltips were the browser's default `<title>` hover, and there was only one way to look at the data. This makes the tracked time harder to read at a glance and to explore. This PR makes the existing trend chart interactive and adds three new ways to see the same data, all built from scratch with SVG/CSS (no chart library), per the frontend direction.

## What changed

### Trend chart — interactivity

The time window is now decoupled from the bucket. A **range selector** (7 / 30 / 90 days, plus a **Custom** option with from/to date pickers) drives the window, while the day/week/month switch stays as the granularity control. The two combine freely.

The native `<title>` tooltips are replaced by a **custom crosshair**: hovering anywhere in a bucket's column highlights that point on every line and shows a floating tooltip listing each visible task's exact value at that bucket, biggest first, nudged inward so it never spills off the edge. An opt-in **"Values" toggle** labels the data points directly on the chart for when you want the numbers without hovering.

### Three new charts

- **Composition over time** — a stacked bar per bucket, broken down by task, so you can see the total and its makeup at once. Reuses the already-loaded series.
- **Share by task** — a donut of each task's share of the tracked time in the selected range, with the total in the center and a percent/hours legend. Reuses the same series.
- **Daily activity** — a GitHub-style heatmap of hours tracked per day. It shows a fixed trailing year of daily data (its own `get-time-series` request at day granularity, independent of the range/bucket selection), with Monday-started columns, month labels and an intensity legend.

Colors stay tied to each task's palette index, so a task is the same color across the trend chart, the stacked bar and the donut.
