### PR TITLE
Continuous deployment to the home server

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,141 @@
+# Continuous deployment to the self-hosted tower.
+#
+# On every push to `main` (i.e. when a PR is merged), this runs the full test
+# suite on GitHub-hosted runners and — only if everything passes — tells the
+# self-hosted runner living on the tower to pull `main` and rebuild the prod
+# stack. A final job pings Telegram with the outcome.
+#
+# Prerequisites (one-time, see DEPLOY.md → "Continuous deployment"):
+#   - A self-hosted Actions runner installed on the tower with the `ticktask`
+#     label, whose user is in the `docker` group.
+#   - Repository variable  DEPLOY_DIR             — the deployment clone on the
+#     tower (the dir holding docker-compose.prod.yml + the real .env).
+#   - Repository secrets    TELEGRAM_BOT_TOKEN / TELEGRAM_ALERT_CHAT_ID
+#     (optional — the notify job is skipped if unset).
+
+name: Deploy
+
+on:
+  push:
+    branches: [main]
+
+# Never let two deploys of main overlap; queue them instead of cancelling so a
+# rebuild is never interrupted half-way.
+concurrency:
+  group: deploy-main
+  cancel-in-progress: false
+
+jobs:
+  backend-tests:
+    name: Backend tests
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.12", "3.13"]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install uv
+        run: python -m pip install --upgrade pip uv
+      - name: Sync dependencies
+        run: uv sync
+      - name: Lint (syntax errors / undefined names)
+        run: uv run flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics --exclude=.venv
+      - name: Test with pytest
+        run: uv run pytest
+
+  frontend-tests:
+    name: Frontend tests
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: gui
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "18"
+          cache: npm
+          cache-dependency-path: gui/package-lock.json
+      - name: Install dependencies
+        run: npm ci
+      - name: Run tests
+        run: npm run test
+
+  deploy:
+    name: Deploy to the tower
+    needs: [backend-tests, frontend-tests]
+    runs-on: [self-hosted, ticktask]
+    steps:
+      - name: Pull main and rebuild the prod stack
+        env:
+          DEPLOY_DIR: ${{ vars.DEPLOY_DIR }}
+        run: |
+          set -euo pipefail
+          if [ -z "${DEPLOY_DIR}" ]; then
+            echo "::error::DEPLOY_DIR repository variable is not set." >&2
+            exit 1
+          fi
+          cd "${DEPLOY_DIR}"
+          echo "Deploying in $(pwd)"
+          git fetch --prune origin
+          git reset --hard origin/main
+          docker compose -f docker-compose.prod.yml --profile public up \
+            --build -d --remove-orphans
+
+      - name: Wait for the app to become healthy
+        run: |
+          set -euo pipefail
+          for i in $(seq 1 30); do
+            if curl -fsS http://localhost/api/openapi.json >/dev/null 2>&1; then
+              echo "Healthy after attempt ${i}."
+              exit 0
+            fi
+            echo "Not ready yet (attempt ${i}/30)…"
+            sleep 5
+          done
+          echo "::error::App did not become healthy within ~150s." >&2
+          exit 1
+
+      - name: Prune dangling images
+        if: always()
+        run: docker image prune -f || true
+
+  notify:
+    name: Notify via Telegram
+    needs: [backend-tests, frontend-tests, deploy]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send the outcome to Telegram
+        env:
+          TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          CHAT_ID: ${{ secrets.TELEGRAM_ALERT_CHAT_ID }}
+          DEPLOY_RESULT: ${{ needs.deploy.result }}
+          BE_RESULT: ${{ needs.backend-tests.result }}
+          FE_RESULT: ${{ needs.frontend-tests.result }}
+          SHA: ${{ github.sha }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          if [ -z "${TOKEN}" ] || [ -z "${CHAT_ID}" ]; then
+            echo "Telegram secrets not set; skipping notification."
+            exit 0
+          fi
+          short_sha="${SHA:0:7}"
+          if [ "${DEPLOY_RESULT}" = "success" ]; then
+            text="✅ TickTask desplegado en la torre (commit ${short_sha})."
+          elif [ "${BE_RESULT}" != "success" ] || [ "${FE_RESULT}" != "success" ]; then
+            text="❌ Despliegue abortado: fallaron los tests (backend=${BE_RESULT}, frontend=${FE_RESULT}) para ${short_sha}. Logs: ${RUN_URL}"
+          else
+            text="❌ Falló el despliegue en la torre (deploy=${DEPLOY_RESULT}) para ${short_sha}. Logs: ${RUN_URL}"
+          fi
+          curl -fsS "https://api.telegram.org/bot${TOKEN}/sendMessage" \
+            --data-urlencode "chat_id=${CHAT_ID}" \
+            --data-urlencode "text=${text}" >/dev/null
+          echo "Notification sent."

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,15 +1,15 @@
-# Continuous deployment to the self-hosted tower.
+# Continuous deployment to the self-hosted home server.
 #
 # On every push to `main` (i.e. when a PR is merged), this runs the full test
 # suite on GitHub-hosted runners and — only if everything passes — tells the
-# self-hosted runner living on the tower to pull `main` and rebuild the prod
+# self-hosted runner living on the home server to pull `main` and rebuild the prod
 # stack. A final job pings Telegram with the outcome.
 #
 # Prerequisites (one-time, see DEPLOY.md → "Continuous deployment"):
-#   - A self-hosted Actions runner installed on the tower with the `ticktask`
+#   - A self-hosted Actions runner installed on the home server with the `ticktask`
 #     label, whose user is in the `docker` group.
 #   - Repository variable  DEPLOY_DIR             — the deployment clone on the
-#     tower (the dir holding docker-compose.prod.yml + the real .env).
+#     home server (the dir holding docker-compose.prod.yml + the real .env).
 #   - Repository secrets    TELEGRAM_BOT_TOKEN / TELEGRAM_ALERT_CHAT_ID
 #     (optional — the notify job is skipped if unset).
 
@@ -68,7 +68,7 @@ jobs:
         run: npm run test
 
   deploy:
-    name: Deploy to the tower
+    name: Deploy to the home server
     needs: [backend-tests, frontend-tests]
     runs-on: [self-hosted, ticktask]
     steps:
@@ -129,11 +129,11 @@ jobs:
           fi
           short_sha="${SHA:0:7}"
           if [ "${DEPLOY_RESULT}" = "success" ]; then
-            text="✅ TickTask desplegado en la torre (commit ${short_sha})."
+            text="✅ TickTask deployed to the home server (commit ${short_sha})."
           elif [ "${BE_RESULT}" != "success" ] || [ "${FE_RESULT}" != "success" ]; then
-            text="❌ Despliegue abortado: fallaron los tests (backend=${BE_RESULT}, frontend=${FE_RESULT}) para ${short_sha}. Logs: ${RUN_URL}"
+            text="❌ Deploy aborted: tests failed (backend=${BE_RESULT}, frontend=${FE_RESULT}) for ${short_sha}. Logs: ${RUN_URL}"
           else
-            text="❌ Falló el despliegue en la torre (deploy=${DEPLOY_RESULT}) para ${short_sha}. Logs: ${RUN_URL}"
+            text="❌ Deploy to the home server failed (deploy=${DEPLOY_RESULT}) for ${short_sha}. Logs: ${RUN_URL}"
           fi
           curl -fsS "https://api.telegram.org/bot${TOKEN}/sendMessage" \
             --data-urlencode "chat_id=${CHAT_ID}" \

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -4,7 +4,9 @@ name: Frontend
 
 on:
   push:
-    branches: [ "**" ]
+    # `main` is tested (and then deployed) by deploy.yml, so skip it here to
+    # avoid running the suite twice on every merge.
+    branches-ignore: [ "main" ]
 
 jobs:
   test:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -5,7 +5,9 @@ name: Python package
 
 on:
   push:
-    branches: [ "**" ]
+    # `main` is tested (and then deployed) by deploy.yml, so skip it here to
+    # avoid running the suite twice on every merge.
+    branches-ignore: [ "main" ]
 
 jobs:
   build:

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -143,7 +143,7 @@ or just copy `/data/db.sqlite3` from the volume while the stack is stopped.
 
 `.github/workflows/deploy.yml` deploys automatically on every push to `main`
 (i.e. when a PR is merged): it runs the full test suite on GitHub-hosted runners
-and, **only if everything passes**, tells a **self-hosted runner on the tower**
+and, **only if everything passes**, tells a **self-hosted runner on the home server**
 to pull `main` and rebuild the stack, then health-checks the app and pings
 Telegram with the outcome.
 
@@ -151,7 +151,7 @@ The runner connects **outbound** to GitHub, so there are no open ports and
 nothing to expose — the same reason the rest of the stack is outbound-only. It is
 independent from the Tailscale SSH access; you don't need SSH for deploys.
 
-### One-time setup on the tower
+### One-time setup on the home server
 
 1. **Deploy from a git clone.** The runner deploys *in place* from an existing
    clone that holds the real `.env` and owns the running Docker volumes (so your
@@ -161,7 +161,7 @@ independent from the Tailscale SSH access; you don't need SSH for deploys.
 
 2. **Install the runner.** In GitHub: **repo → Settings → Actions → Runners →
    New self-hosted runner** (Linux/x64). Follow the shown `download` + `config.sh`
-   commands on the tower; when `config.sh` asks for labels, add **`ticktask`**
+   commands on the home server; when `config.sh` asks for labels, add **`ticktask`**
    (the workflow targets `runs-on: [self-hosted, ticktask]`). Run it as a
    service so it survives reboots:
 

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -139,6 +139,66 @@ docker compose -f docker-compose.prod.yml exec backend \
 
 or just copy `/data/db.sqlite3` from the volume while the stack is stopped.
 
+## 6. Continuous deployment (optional)
+
+`.github/workflows/deploy.yml` deploys automatically on every push to `main`
+(i.e. when a PR is merged): it runs the full test suite on GitHub-hosted runners
+and, **only if everything passes**, tells a **self-hosted runner on the tower**
+to pull `main` and rebuild the stack, then health-checks the app and pings
+Telegram with the outcome.
+
+The runner connects **outbound** to GitHub, so there are no open ports and
+nothing to expose — the same reason the rest of the stack is outbound-only. It is
+independent from the Tailscale SSH access; you don't need SSH for deploys.
+
+### One-time setup on the tower
+
+1. **Deploy from a git clone.** The runner deploys *in place* from an existing
+   clone that holds the real `.env` and owns the running Docker volumes (so your
+   database is preserved). If you already deploy by `git pull` from a directory,
+   use that one. Otherwise clone the repo and do the first manual launch (steps
+   2–4) there.
+
+2. **Install the runner.** In GitHub: **repo → Settings → Actions → Runners →
+   New self-hosted runner** (Linux/x64). Follow the shown `download` + `config.sh`
+   commands on the tower; when `config.sh` asks for labels, add **`ticktask`**
+   (the workflow targets `runs-on: [self-hosted, ticktask]`). Run it as a
+   service so it survives reboots:
+
+   ```sh
+   sudo ./svc.sh install
+   sudo ./svc.sh start
+   ```
+
+   The runner's user must be able to run Docker without sudo:
+
+   ```sh
+   sudo usermod -aG docker "$USER"   # then re-login (or reboot) so it takes effect
+   ```
+
+3. **Point the workflow at your deploy directory.** In GitHub: **repo → Settings
+   → Secrets and variables → Actions → Variables → New repository variable**,
+   name `DEPLOY_DIR`, value the absolute path of the clone from step 1 (e.g.
+   `/home/david/ticktask`).
+
+4. **(Optional) Telegram deploy alerts.** Add two **repository secrets** (same
+   screen, *Secrets* tab): `TELEGRAM_BOT_TOKEN` (your bot token) and
+   `TELEGRAM_ALERT_CHAT_ID` (the chat to notify — your own chat id; it's stored on
+   your `UserTelegramSettings` row in the Django admin once you've linked the
+   bot). If either is missing, the notify step is simply skipped.
+
+### How a deploy runs
+
+On merge to `main`: tests run → if green, the runner does
+`git fetch && git reset --hard origin/main` in `DEPLOY_DIR` and
+`docker compose -f docker-compose.prod.yml --profile public up --build -d`
+(migrations + `collectstatic` still run on backend start), waits for
+`http://localhost/api/openapi.json` to answer, prunes dangling images, and
+reports success/failure to Telegram. Watch it under the repo's **Actions** tab.
+
+You can still deploy manually any time with the `git pull` + `up --build -d`
+commands in section 5 — the CD just automates exactly that.
+
 ## Notes & limits
 
 - **SQLite** is fine for a small private deployment but serializes writes. If the


### PR DESCRIPTION
Adds automated deployment to the self-hosted home server on every update of `main` (i.e. when a PR is merged), gated on the full test suite.

## What it does

On a push to `main`, `.github/workflows/deploy.yml` runs the backend suite (pytest on Python 3.12 and 3.13) and the frontend suite (Vitest) on GitHub-hosted runners. Only if all of them pass, a **self-hosted runner on the home server** pulls `main` and rebuilds the production stack in place:

```
git fetch --prune origin
git reset --hard origin/main
docker compose -f docker-compose.prod.yml --profile public up --build -d --remove-orphans
```

It then health-checks the app by polling `http://localhost/api/openapi.json` (through nginx → backend, so it validates the whole chain), prunes dangling images, and a final job reports the outcome to Telegram.

## Design notes

- **Triggers on `push: [main]`**, which fires on every update of the branch — PR merges (merge/squash/rebase) and direct pushes alike — so no path is missed.
- **Deploys in place** from an existing clone (the `DEPLOY_DIR` variable) that holds the real `.env` and owns the Docker volumes, so the database is preserved. `git reset --hard origin/main` keeps the deploy idempotent even if the clone has local drift; `.env` is git-ignored and survives.
- **Migrations and `collectstatic`** already run on backend container start, so a deploy is just pull + rebuild.
- The per-branch `python-package.yml` / `frontend.yml` workflows now use `branches-ignore: [main]` so the suite isn't run twice on a merge — `deploy.yml` owns testing on `main`.
- The deploy job is **concurrency-guarded** so two deploys never overlap, and the Telegram notify job runs with `always()` so it reports test failures too. It is skipped cleanly when the Telegram secrets are absent.

## One-time setup (documented in DEPLOY.md)

- A self-hosted Actions runner installed on the home server with the `ticktask` label, whose user is in the `docker` group.
- Repository variable `DEPLOY_DIR` — the absolute path of the deployment clone on the home server.
- Optional repository secrets `TELEGRAM_BOT_TOKEN` and `TELEGRAM_ALERT_CHAT_ID` for the deploy notifications.