### PR TITLE
docs: fix outdated DEPLOY_DIR example path in DEPLOY.md

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -179,7 +179,7 @@ independent from the Tailscale SSH access; you don't need SSH for deploys.
 3. **Point the workflow at your deploy directory.** In GitHub: **repo → Settings
    → Secrets and variables → Actions → Variables → New repository variable**,
    name `DEPLOY_DIR`, value the absolute path of the clone from step 1 (e.g.
-   `/home/david/ticktask`).
+   `/home/david/Escritorio/deploy/TickTask`).
 
 4. **(Optional) Telegram deploy alerts.** Add two **repository secrets** (same
    screen, *Secrets* tab): `TELEGRAM_BOT_TOKEN` (your bot token) and


### PR DESCRIPTION
## Summary
- `DEPLOY_DIR` example in DEPLOY.md still referenced the old clone layout (`/home/david/ticktask`); updated it to match the current deploy path (`/home/david/Escritorio/deploy/TickTask`).

## Test plan
- [x] `grep` over the final file no longer finds the old path.